### PR TITLE
Fix RemedialActionScheduleResponseKInd typo in RAS FAP XML files

### DIFF
--- a/Instance/Belgovia/NetworkCode/cimxml/Belgovia_RAS_FAP.xml
+++ b/Instance/Belgovia/NetworkCode/cimxml/Belgovia_RAS_FAP.xml
@@ -52,7 +52,7 @@
   
   <nc:RemedialActionScheduleResponse rdf:ID="_c11ac0dd-2e7d-4320-9abb-b98bfc88f4ee">
     <cim:RemedialActionScheduleResponse.mRID>c11ac0dd-2e7d-4320-9abb-b98bfc88f4ee</cim:RemedialActionScheduleResponse.mRID>
-    <nc:RemedialActionScheduleResponse.kind rdf:resource="https://cim4.eu/ns/nc#RemedialActionScheduleResponseKInd.accepted"/>
+    <nc:RemedialActionScheduleResponse.kind rdf:resource="https://cim4.eu/ns/nc#RemedialActionScheduleResponseKind.accepted"/>
     <nc:RemedialActionScheduleResponse.RemedialActionSchedule rdf:resource="#_17527637-6099-4ee6-8b21-fea8dfec4c75"/>	
     <nc:RemedialActionScheduleResponse.RespondingEntity rdf:resource="#_b9fbb881-573b-4e98-9b7b-31f00a45ebe0"/>	
   </nc:RemedialActionScheduleResponse>

--- a/Instance/Svedala/NetworkCode/cimxml/Svedala_FAP_RAS_simple.xml
+++ b/Instance/Svedala/NetworkCode/cimxml/Svedala_FAP_RAS_simple.xml
@@ -58,7 +58,7 @@
   
   <nc:RemedialActionScheduleResponse rdf:ID="_c11ac0dd-2e7d-4320-9abb-b98bfc88f4ee">
     <nc:RemedialActionScheduleResponse.mRID>c11ac0dd-2e7d-4320-9abb-b98bfc88f4ee</nc:RemedialActionScheduleResponse.mRID>
-    <nc:RemedialActionScheduleResponse.kind rdf:resource="https://cim4.eu/ns/nc#RemedialActionScheduleResponseKInd.waiting"/>
+    <nc:RemedialActionScheduleResponse.kind rdf:resource="https://cim4.eu/ns/nc#RemedialActionScheduleResponseKind.waiting"/>
     <nc:RemedialActionScheduleResponse.RemedialActionSchedule rdf:resource="#_17527637-6099-4ee6-8b21-fea8dfec4c75"/>	
     <nc:RemedialActionScheduleResponse.RespondingEntity rdf:resource="#_b9fbb881-573b-4e98-9b7b-31f00a45ebe0"/>	
   </nc:RemedialActionScheduleResponse>


### PR DESCRIPTION
## Summary

- Fixes capitalisation typo in RemedialActionScheduleResponse.kind enum values: KInd -> Kind
- Affects 2 cimxml files: Belgovia_RAS_FAP.xml and Svedala_FAP_RAS_simple.xml
- SHACL constraint: RemedialActionScheduleResponse.kind-datatype in RemedialActionSchedule-AP-Con-Simple-SHACL.ttl

## Test plan

- [x] SHACL validation against NCP/CurrentRelease/SHACL/RemedialActionSchedule-AP-Con-Simple-SHACL.ttl passes for both files
- [x] No remaining KInd occurrences in cimxml files

Fixes #252

Generated with Claude Code