### PR TITLE
Fix issue #254: Replace boundary EquivalentInjection in SIPS_UC_2 RA

### DIFF
--- a/Instance/Belgovia/Grid/cimxml/20220615T2230Z_2D_Belgovia_SSH_1.xml
+++ b/Instance/Belgovia/Grid/cimxml/20220615T2230Z_2D_Belgovia_SSH_1.xml
@@ -767,6 +767,9 @@
   <cim:Terminal rdf:about="#_77f04391-aa23-49b6-b3e9-6089130bb5d5">
     <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
   </cim:Terminal>
+  <cim:Terminal rdf:ID="_515bd41d-c5bc-4d0c-bf0f-449875c7bd9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
   <cim:VoltageLimit rdf:about="#_f4546d12-7aa2-14ec-f126-944c963b97ed">
     <cim:VoltageLimit.value>247.5</cim:VoltageLimit.value>
   </cim:VoltageLimit>

--- a/Instance/Belgovia/Grid/cimxml/20220615T2230Z_2D_Belgovia_SSH_1.xml
+++ b/Instance/Belgovia/Grid/cimxml/20220615T2230Z_2D_Belgovia_SSH_1.xml
@@ -386,6 +386,11 @@
     <cim:EquivalentInjection.p>-26.7316</cim:EquivalentInjection.p>
     <cim:EquivalentInjection.q>2.1787</cim:EquivalentInjection.q>
   </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_7c43d75f-f169-4525-9a55-ef54c6f95f3c">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>-26.7316</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>2.1787</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
   <cim:EquivalentInjection rdf:about="#_579381e6-1e32-457b-a208-32f905b1e19e">
     <cim:Equipment.inService>true</cim:Equipment.inService>
     <cim:EquivalentInjection.p>-576.42</cim:EquivalentInjection.p>

--- a/Instance/Belgovia/Grid/cimxml/20220615T2230Z_2D_Belgovia_SSH_1.xml
+++ b/Instance/Belgovia/Grid/cimxml/20220615T2230Z_2D_Belgovia_SSH_1.xml
@@ -388,8 +388,8 @@
   </cim:EquivalentInjection>
   <cim:EquivalentInjection rdf:about="#_7c43d75f-f169-4525-9a55-ef54c6f95f3c">
     <cim:Equipment.inService>true</cim:Equipment.inService>
-    <cim:EquivalentInjection.p>-26.7316</cim:EquivalentInjection.p>
-    <cim:EquivalentInjection.q>2.1787</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.p>0</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>0</cim:EquivalentInjection.q>
   </cim:EquivalentInjection>
   <cim:EquivalentInjection rdf:about="#_579381e6-1e32-457b-a208-32f905b1e19e">
     <cim:Equipment.inService>true</cim:Equipment.inService>

--- a/Instance/Belgovia/Grid/cimxml/20220615T2230Z_2D_Belgovia_SV_1.xml
+++ b/Instance/Belgovia/Grid/cimxml/20220615T2230Z_2D_Belgovia_SV_1.xml
@@ -338,6 +338,11 @@
     <cim:SvPowerFlow.p>-26.7316</cim:SvPowerFlow.p>
     <cim:SvPowerFlow.q>2.1787</cim:SvPowerFlow.q>
   </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_211e4a73-dddb-4685-ba53-77111e7248b7">
+    <cim:SvPowerFlow.Terminal rdf:resource="#_515bd41d-c5bc-4d0c-bf0f-449875c7bd9b"/>
+    <cim:SvPowerFlow.p>-26.7316</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>2.1787</cim:SvPowerFlow.q>
+  </cim:SvPowerFlow>
   <cim:SvPowerFlow rdf:ID="_461b009b-4ee1-46d5-807d-b04f01f9d539">
     <cim:SvPowerFlow.Terminal rdf:resource="#_ca0f7e2e-3442-4ada-a704-91f319c0ebe3"/>
     <cim:SvPowerFlow.p>78.9071</cim:SvPowerFlow.p>
@@ -510,6 +515,10 @@
   </cim:SvStatus>
   <cim:SvStatus rdf:ID="_9faef913-ca08-4368-87f8-6d9eef94eb4a">
     <cim:SvStatus.ConductingEquipment rdf:resource="#_9dc33660-e284-4c74-bb9a-44604390634e"/>
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_ccb70d1c-4630-47c7-a4e5-656b9f6796bf">
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_7c43d75f-f169-4525-9a55-ef54c6f95f3c"/>
     <cim:SvStatus.inService>true</cim:SvStatus.inService>
   </cim:SvStatus>
   <cim:SvStatus rdf:ID="_6de0ac22-0ee3-40f3-8343-c8fede7024cc">

--- a/Instance/Belgovia/Grid/cimxml/20220615T2230Z_2D_Belgovia_SV_1.xml
+++ b/Instance/Belgovia/Grid/cimxml/20220615T2230Z_2D_Belgovia_SV_1.xml
@@ -340,8 +340,8 @@
   </cim:SvPowerFlow>
   <cim:SvPowerFlow rdf:ID="_211e4a73-dddb-4685-ba53-77111e7248b7">
     <cim:SvPowerFlow.Terminal rdf:resource="#_515bd41d-c5bc-4d0c-bf0f-449875c7bd9b"/>
-    <cim:SvPowerFlow.p>-26.7316</cim:SvPowerFlow.p>
-    <cim:SvPowerFlow.q>2.1787</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.p>0</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>0</cim:SvPowerFlow.q>
   </cim:SvPowerFlow>
   <cim:SvPowerFlow rdf:ID="_461b009b-4ee1-46d5-807d-b04f01f9d539">
     <cim:SvPowerFlow.Terminal rdf:resource="#_ca0f7e2e-3442-4ada-a704-91f319c0ebe3"/>

--- a/Instance/Belgovia/Grid/cimxml/20220615T2230Z_2D_Belgovia_TP_1.xml
+++ b/Instance/Belgovia/Grid/cimxml/20220615T2230Z_2D_Belgovia_TP_1.xml
@@ -328,6 +328,9 @@
   <cim:Terminal rdf:about="#_27f8309f-fa32-9a5a-4673-6a65cce3e2f9">
     <cim:Terminal.TopologicalNode rdf:resource="#_353bafc9-0738-b9ee-03ce-96345c77c73f"/>
   </cim:Terminal>
+  <cim:Terminal rdf:about="#_515bd41d-c5bc-4d0c-bf0f-449875c7bd9b">
+    <cim:Terminal.TopologicalNode rdf:resource="#_353bafc9-0738-b9ee-03ce-96345c77c73f"/>
+  </cim:Terminal>
   <cim:Terminal rdf:about="#_22af3121-1a66-4546-bd80-4371f417c644">
     <cim:Terminal.TopologicalNode rdf:resource="#_ee7873a3-23c6-d5cb-df42-0473140b7aba"/>
   </cim:Terminal>

--- a/Instance/Belgovia/Grid/cimxml/20220615T2230Z__Belgovia_EQ_1.xml
+++ b/Instance/Belgovia/Grid/cimxml/20220615T2230Z__Belgovia_EQ_1.xml
@@ -893,6 +893,14 @@
     <cim:IdentifiedObject.name>Injection_GA_BO2</cim:IdentifiedObject.name>
     <eu:IdentifiedObject.shortName>BO-I-XCA_AL1</eu:IdentifiedObject.shortName>
   </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_7c43d75f-f169-4525-9a55-ef54c6f95f3c">
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1"/>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361"/>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:IdentifiedObject.description>Internal-side EquivalentInjection for the HVDC link TieLine_GA_BO2 at the Belgovia internal bus N1230991550. Used by SIPS_UC_2 run-back actions instead of the boundary-point injection Injection_GA_BO2.</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.mRID>7c43d75f-f169-4525-9a55-ef54c6f95f3c</cim:IdentifiedObject.mRID>
+    <cim:IdentifiedObject.name>Injection_GA_BO2_internal</cim:IdentifiedObject.name>
+  </cim:EquivalentInjection>
   <cim:EquivalentInjection rdf:ID="_14b352cb-5574-40c5-bf83-0ed3574554a3">
     <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14"/>
     <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa2"/>
@@ -2067,6 +2075,13 @@
     <cim:IdentifiedObject.mRID>27f8309f-fa32-9a5a-4673-6a65cce3e2f9</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Cub_1</cim:IdentifiedObject.name>
     <cim:Terminal.ConductingEquipment rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da"/>
+    <cim:Terminal.ConnectivityNode rdf:resource="#_29a37807-af63-402d-ac87-2e248d844793"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_515bd41d-c5bc-4d0c-bf0f-449875c7bd9b">
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:IdentifiedObject.mRID>515bd41d-c5bc-4d0c-bf0f-449875c7bd9b</cim:IdentifiedObject.mRID>
+    <cim:IdentifiedObject.name>Terminal_Injection_GA_BO2_internal</cim:IdentifiedObject.name>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_7c43d75f-f169-4525-9a55-ef54c6f95f3c"/>
     <cim:Terminal.ConnectivityNode rdf:resource="#_29a37807-af63-402d-ac87-2e248d844793"/>
   </cim:Terminal>
   <cim:Terminal rdf:ID="_22af3121-1a66-4546-bd80-4371f417c644">

--- a/Instance/Belgovia/NetworkCode/cimxml/Belgovia_RA.xml
+++ b/Instance/Belgovia/NetworkCode/cimxml/Belgovia_RA.xml
@@ -146,11 +146,11 @@
     <nc:RemedialActionScheme.kind rdf:resource="https://cim4.eu/ns/nc#RemedialActionSchemeKind.sips" />
     <nc:RemedialActionScheme.normalArmed>true</nc:RemedialActionScheme.normalArmed>
   </nc:RemedialActionScheme>
-    <!-- in case of import on TieLine_GA_BO2 decprease the power to 10 MW--> 
+    <!-- in case of import on TieLine_GA_BO2 decrease the power to 10 MW--> 
   <nc:Stage rdf:ID="_215c0331-cf8e-4499-b9b5-bc3cffd3f3b3">
     <cim:IdentifiedObject.mRID>215c0331-cf8e-4499-b9b5-bc3cffd3f3b3</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>SIPS_UC2_Runback_import.</cim:IdentifiedObject.name>
-    <cim:IdentifiedObject.description>SIPS_UC2_Runback_import. In case of import on TieLine_GA_BO2 decprease the power to 10 MW</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.description>SIPS_UC2_Runback_import. In case of import on TieLine_GA_BO2 decrease the power to 10 MW</cim:IdentifiedObject.description>
     <nc:Stage.GridStateAlterationCollection rdf:resource="#_d91f1368-bd8c-456a-9088-0dd4b9620b21" />
     <nc:Stage.RemedialActionScheme rdf:resource="#_3ecde63d-c87f-4947-a1f2-3622dc2092ba" />
     <nc:Stage.priority>0</nc:Stage.priority>
@@ -166,7 +166,7 @@
     <cim:IdentifiedObject.mRID>b591f3b9-e7e6-4625-b1d2-f53dec63ced1</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Set EI to 10</cim:IdentifiedObject.name>
     <cim:IdentifiedObject.description>Set power on EquivalentInjection to 10 MW</cim:IdentifiedObject.description>
-    <nc:EquivalentInjectionAction.EquivalentInjection rdf:resource="#_9dc33660-e284-4c74-bb9a-44604390634e" />
+    <nc:EquivalentInjectionAction.EquivalentInjection rdf:resource="#_7c43d75f-f169-4525-9a55-ef54c6f95f3c" />
   </nc:EquivalentInjectionAction>
    <nc:StaticPropertyRange rdf:ID="_de394860-8c5f-48b4-869c-c09f5247a6ec">
     <cim:IdentifiedObject.mRID>de394860-8c5f-48b4-869c-c09f5247a6ec</cim:IdentifiedObject.mRID>
@@ -219,7 +219,7 @@
     <nc:PinGate.GateOutput rdf:resource="#_b73c5258-2fb6-4e8a-8b0a-61d84a52ee27" />
     <!-- Added attribute, which says this pin is controllable for if it should be a possible input or not. False means that it is not possible that this input activates the SIPS in default settings (but could be possible if we change current settings in attribute "enabled" SSI profile). -->
   </nc:PinGate>
-    <!-- in case of export on TieLine_GA_BO2 decprease the power to 10 MW--> 
+    <!-- in case of export on TieLine_GA_BO2 decrease the power to 10 MW--> 
   <nc:Stage rdf:ID="_89705a24-34bd-493e-a572-c32f25106e3b">
     <cim:IdentifiedObject.mRID>89705a24-34bd-493e-a572-c32f25106e3b</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>TL decrease 10 MW</cim:IdentifiedObject.name>
@@ -238,7 +238,7 @@
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.mRID>12b3c4e6-2104-4499-b003-1248ef533e13</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Set power on EquivalentInjection to -10 MW</cim:IdentifiedObject.name>
-    <nc:EquivalentInjectionAction.EquivalentInjection rdf:resource="#_9dc33660-e284-4c74-bb9a-44604390634e" />
+    <nc:EquivalentInjectionAction.EquivalentInjection rdf:resource="#_7c43d75f-f169-4525-9a55-ef54c6f95f3c" />
   </nc:EquivalentInjectionAction>
    <nc:StaticPropertyRange rdf:ID="_bcc5cc7d-1c60-4014-9c5f-fb16af94bba8">
     <cim:IdentifiedObject.mRID>bcc5cc7d-1c60-4014-9c5f-fb16af94bba8</cim:IdentifiedObject.mRID>


### PR DESCRIPTION
There was no EquivalentInjection in the model which is not a BoundaryPoint.
Add Injection_GA_BO2_internal (_7c43d75f) at the internal Belgovia bus N1230991550 (ConnectivityNode _29a37807, not at any BoundaryPoint). Update both EquivalentInjectionAction elements in SIPS_UC_2 to reference the new injection instead of the boundary-point Injection_GA_BO2 (_9dc33660), which goes out of service in a CGM.
