### PR TITLE
Point PropertyReference associations at CIM17 URIs (issue #358)

### DIFF
--- a/Instance/Belgovia/NetworkCode/cimxml/Belgovia_RA.xml
+++ b/Instance/Belgovia/NetworkCode/cimxml/Belgovia_RA.xml
@@ -112,7 +112,7 @@
   </nc:GridStateAlterationRemedialAction>
   <nc:RotatingMachineAction rdf:ID="_7be59519-0083-4845-a587-cb391ed16a1d">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_d874f8e3-7272-44b8-95ba-18f10449f036"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/RotatingMachine.p"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#RotatingMachine.p"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.mRID>7be59519-0083-4845-a587-cb391ed16a1d</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Rotatig Mach 2</cim:IdentifiedObject.name>
@@ -120,7 +120,7 @@
   </nc:RotatingMachineAction>
   <nc:RotatingMachineAction rdf:ID="_a38d4a85-e221-43ec-b7bb-122f7c95f06e">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_d874f8e3-7272-44b8-95ba-18f10449f036"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/RotatingMachine.p"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#RotatingMachine.p"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.mRID>a38d4a85-e221-43ec-b7bb-122f7c95f06e</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Rotatig Mach 1</cim:IdentifiedObject.name>
@@ -128,7 +128,7 @@
   </nc:RotatingMachineAction>
   <nc:ShuntCompensatorModification rdf:ID="_ddb3c55f-b2ec-414e-baa3-592829e2edb2">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_7acbe48a-bd54-4cd7-af2e-87768357c559"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/ShuntCompensator.sections"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#ShuntCompensator.sections"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.mRID>ddb3c55f-b2ec-414e-baa3-592829e2edb2</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Shunt action 1</cim:IdentifiedObject.name>
@@ -136,7 +136,7 @@
   </nc:ShuntCompensatorModification>
   <nc:TapPositionAction rdf:ID="_bf7f0ef4-dad3-4322-b2be-5ace59837e60">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_5e5ff13e-2043-4468-9351-01920d3d9504"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/TapChanger.step"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#TapChanger.step"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>tap position action on this transformer : Transformer ID: _84ed55f4-61f5-4d9d-8755-bba7b877a246</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>bf7f0ef4-dad3-4322-b2be-5ace59837e60</cim:IdentifiedObject.mRID>
@@ -145,7 +145,7 @@
   </nc:TapPositionAction>
   <nc:TapPositionAction rdf:ID="_14d59f97-7c9b-4921-a3b1-5883def956fb">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_70b696ac-c38f-4528-8d65-ba707c0b72e1"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/TapChanger.step"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#TapChanger.step"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>tap position action on this transformer : Transformer ID: _84ed55f4-61f5-4d9d-8755-bba7b877a246</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>14d59f97-7c9b-4921-a3b1-5883def956fb</cim:IdentifiedObject.mRID>
@@ -176,7 +176,7 @@
   </nc:GridStateAlterationCollection>  
   <nc:EquivalentInjectionAction rdf:ID="_b591f3b9-e7e6-4625-b1d2-f53dec63ced1">
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_d91f1368-bd8c-456a-9088-0dd4b9620b21" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/EquivalentInjection.p" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#EquivalentInjection.p" />
     <cim:IdentifiedObject.mRID>b591f3b9-e7e6-4625-b1d2-f53dec63ced1</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Set EI to 10</cim:IdentifiedObject.name>
     <cim:IdentifiedObject.description>Set power on EquivalentInjection to 10 MW</cim:IdentifiedObject.description>
@@ -189,7 +189,7 @@
     <nc:RangeConstraint.GridStateAlteration rdf:resource="#_b591f3b9-e7e6-4625-b1d2-f53dec63ced1"/>
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/EquivalentInjection.p"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#EquivalentInjection.p"/>
     <nc:RangeConstraint.normalValue>10</nc:RangeConstraint.normalValue>
   </nc:StaticPropertyRange>
     <!-- trigger conditions: if any line tripped (contingency triggered) and import on TieLine_GA_BO2 higher than 20 MW (EquivalentInjection power lower than -20 MW)-->  
@@ -248,7 +248,7 @@
   </nc:GridStateAlterationCollection>  
   <nc:EquivalentInjectionAction rdf:ID="_12b3c4e6-2104-4499-b003-1248ef533e13">
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_84477640-5bd9-4076-bfe8-415ae0ef8d6e" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/EquivalentInjection.p" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#EquivalentInjection.p" />
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.mRID>12b3c4e6-2104-4499-b003-1248ef533e13</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Set power on EquivalentInjection to -10 MW</cim:IdentifiedObject.name>
@@ -260,7 +260,7 @@
     <nc:RangeConstraint.GridStateAlteration rdf:resource="#_12b3c4e6-2104-4499-b003-1248ef533e13"/>
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/EquivalentInjection.p"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#EquivalentInjection.p"/>
     <nc:RangeConstraint.normalValue>-10</nc:RangeConstraint.normalValue>
   </nc:StaticPropertyRange>
     <!-- trigger conditions if any line tripped (contingency triggered) and export on TieLine_GA_BO2 higher than 20 MW (EquivalentInjection power higher than 20 MW)-->  
@@ -348,7 +348,7 @@
   </nc:GridStateAlterationCollection>
   <nc:TopologyAction rdf:ID="_af64e952-7fc1-4cb7-8881-a0c2b3256982">
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_24e0aad8-46eb-43a5-8846-a59d64edb10e" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open" />
     <cim:IdentifiedObject.mRID>af64e952-7fc1-4cb7-8881-a0c2b3256982</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Switch1_BO-Line_6_OPEN</cim:IdentifiedObject.name>
     <nc:TopologyAction.Switch rdf:resource="#_0a84038e-1952-4d9d-9909-3b49c364a1ac" />
@@ -361,12 +361,12 @@
     <nc:RangeConstraint.GridStateAlteration rdf:resource="#_af64e952-7fc1-4cb7-8881-a0c2b3256982"/>
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:RangeConstraint.normalValue>1</nc:RangeConstraint.normalValue>
   </nc:StaticPropertyRange>
   <nc:TopologyAction rdf:ID="_bdb13ef7-1338-4f34-b42b-5e8ad34989b1">
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_24e0aad8-46eb-43a5-8846-a59d64edb10e" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open" />
     <cim:IdentifiedObject.mRID>bdb13ef7-1338-4f34-b42b-5e8ad34989b1</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Switch2_BO-Line_6_OPEN</cim:IdentifiedObject.name>
     <nc:TopologyAction.Switch rdf:resource="#_ddc148fc-3abd-459d-aec1-396283e0def6" />
@@ -379,7 +379,7 @@
     <nc:RangeConstraint.GridStateAlteration rdf:resource="#_bdb13ef7-1338-4f34-b42b-5e8ad34989b1"/>
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:RangeConstraint.normalValue>1</nc:RangeConstraint.normalValue>
   </nc:StaticPropertyRange>
   <nc:StageTrigger rdf:ID="_38ac48fd-027f-45a9-90c9-08d9abd7b0d2">
@@ -427,7 +427,7 @@
   </nc:GridStateAlterationCollection>
   <nc:TopologyAction rdf:ID="_ecd76354-2372-4eca-af47-530abc00549c">
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_44027a5c-bfb3-4a50-823e-e8303c34360f" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open" />
     <cim:IdentifiedObject.mRID>ecd76354-2372-4eca-af47-530abc00549c</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Open TieLine_GA_BO2 breaker</cim:IdentifiedObject.name>
     <nc:TopologyAction.Switch rdf:resource="#_484536e9-762a-49a3-9970-d60b9fae03fe" />
@@ -438,7 +438,7 @@
     <nc:RangeConstraint.GridStateAlteration rdf:resource="#_ecd76354-2372-4eca-af47-530abc00549c"/>
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:RangeConstraint.normalValue>1</nc:RangeConstraint.normalValue>
   </nc:StaticPropertyRange>
   <nc:StageTrigger rdf:ID="_375e7a7b-4710-4efe-b052-134446bef7f8">
@@ -488,7 +488,7 @@
   </nc:GridStateAlterationCollection>
   <nc:TopologyAction rdf:ID="_8b56b2cd-99ac-4fc3-ad3d-eb14153426f3">
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_d660909d-3027-4e60-9a49-b83a14820025" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open" />
     <cim:IdentifiedObject.mRID>8b56b2cd-99ac-4fc3-ad3d-eb14153426f3</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Open breaker BO_Breaker_1</cim:IdentifiedObject.name>
     <nc:TopologyAction.Switch rdf:resource="#_38dfcc80-600f-44e2-8f71-fb595b4f00ac" />
@@ -499,7 +499,7 @@
     <nc:RangeConstraint.GridStateAlteration rdf:resource="#_8b56b2cd-99ac-4fc3-ad3d-eb14153426f3"/>
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:RangeConstraint.normalValue>1</nc:RangeConstraint.normalValue>
   </nc:StaticPropertyRange>
   <nc:StageTrigger rdf:ID="_a1673e05-907a-4d90-b01a-ee4d9c752061">
@@ -549,7 +549,7 @@
   </nc:GridStateAlterationCollection>
   <nc:RotatingMachineAction rdf:ID="_3326ee03-5968-45bb-a88c-6a2185d89da7">
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_cf042533-90b8-4a2e-9955-2ef8b71b5886" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/RotatingMachine.p" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#RotatingMachine.p" />
     <cim:IdentifiedObject.mRID>3326ee03-5968-45bb-a88c-6a2185d89da7</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Set generator BO-G2 to Pmin</cim:IdentifiedObject.name>
     <nc:RotatingMachineAction.RotatingMachine rdf:resource="#_3a3b27be-b18b-4385-b557-6735d733baf0" />
@@ -560,7 +560,7 @@
     <nc:RangeConstraint.GridStateAlteration rdf:resource="#_3326ee03-5968-45bb-a88c-6a2185d89da7"/>
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.down"/>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/RotatingMachine.p"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#RotatingMachine.p"/>
     <nc:RangeConstraint.normalValue>-10</nc:RangeConstraint.normalValue>
   </nc:StaticPropertyRange>
   <nc:StageTrigger rdf:ID="_83b5c01d-2c91-4404-b525-b48c9f6cc3f0">

--- a/Instance/DC-Espheim-Svedala/NetworkCode/cimxml/DC-Espheim-Svedala_RA.xml
+++ b/Instance/DC-Espheim-Svedala/NetworkCode/cimxml/DC-Espheim-Svedala_RA.xml
@@ -195,7 +195,7 @@ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.up" />
     <nc:RangeConstraint.normalValue>250</nc:RangeConstraint.normalValue>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute" />
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/ACDCConverter.targetPpcc" />
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#ACDCConverter.targetPpcc" />
   </nc:StaticPropertyRange>
   <nc:StaticPropertyRange rdf:ID="_f70729cc-9ae8-4e24-b7ed-5ef3c316f362">
     <cim:IdentifiedObject.mRID>f70729cc-9ae8-4e24-b7ed-5ef3c316f362</cim:IdentifiedObject.mRID>
@@ -203,12 +203,12 @@ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.down" />
     <nc:RangeConstraint.normalValue>-250</nc:RangeConstraint.normalValue>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute" />
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/ACDCConverter.targetPpcc" />
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#ACDCConverter.targetPpcc" />
   </nc:StaticPropertyRange>
   <nc:ACDCConverterAction rdf:ID="_3fa0a033-610d-4c0c-ba12-36a6482f5b08">
       <nc:ACDCConverterAction.ACDCConverter rdf:resource="#_038ce404-30dc-4289-b9db-7076cb870b8e" />
       <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_4eb0a454-4796-4598-a0af-788cb478d415" />
-      <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/ACDCConverter.targetPpcc" />
+      <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#ACDCConverter.targetPpcc" />
       <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
       <cim:IdentifiedObject.mRID>3fa0a033-610d-4c0c-ba12-36a6482f5b08</cim:IdentifiedObject.mRID>
       <cim:IdentifiedObject.name>RegHvdcAbsolute_038ce404-30dc-4289-b9db-7076cb870b8e-</cim:IdentifiedObject.name>
@@ -216,7 +216,7 @@ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
   <nc:ACDCConverterAction rdf:ID="_26bed5db-d6bd-44e5-ab95-082453bd0cfa">
     <nc:ACDCConverterAction.ACDCConverter rdf:resource="#_038ce404-30dc-4289-b9db-7076cb870b8e" />
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_df90ad87-bf20-45e5-a75d-a5df84384e0e" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/ACDCConverter.targetPpcc" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#ACDCConverter.targetPpcc" />
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.mRID>26bed5db-d6bd-44e5-ab95-082453bd0cfa</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>RegHvdcAbsolute_038ce404-30dc-4289-b9db-7076cb870b8e-</cim:IdentifiedObject.name>
@@ -227,7 +227,7 @@ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.up" />
     <nc:RangeConstraint.normalValue>250</nc:RangeConstraint.normalValue>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute" />
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/ACDCConverter.targetPpcc" />
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#ACDCConverter.targetPpcc" />
   </nc:StaticPropertyRange>
   <nc:StaticPropertyRange rdf:ID="_fffdf252-9de2-414f-a991-1cd0d2307796">
     <cim:IdentifiedObject.mRID>fffdf252-9de2-414f-a991-1cd0d2307796</cim:IdentifiedObject.mRID>
@@ -235,12 +235,12 @@ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.down" />
     <nc:RangeConstraint.normalValue>-250</nc:RangeConstraint.normalValue>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute" />
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/ACDCConverter.targetPpcc" />
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#ACDCConverter.targetPpcc" />
   </nc:StaticPropertyRange>
   <nc:ACDCConverterAction rdf:ID="_55d1fcd7-fd50-49b4-a960-05c6a585138a">
     <nc:ACDCConverterAction.ACDCConverter rdf:resource="#_e468e6ca-8776-4c22-8f9b-390df610c2fd" />
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_df90ad87-bf20-45e5-a75d-a5df84384e0e" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/ACDCConverter.targetPpcc" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#ACDCConverter.targetPpcc" />
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.mRID>55d1fcd7-fd50-49b4-a960-05c6a585138a</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>RegHvdcAbsolute_e468e6ca-8776-4c22-8f9b-390df610c2fd-</cim:IdentifiedObject.name>
@@ -248,7 +248,7 @@ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
   <nc:ACDCConverterAction rdf:ID="_4285c664-8cb0-4013-826f-347c64ed554b">
     <nc:ACDCConverterAction.ACDCConverter rdf:resource="#_e468e6ca-8776-4c22-8f9b-390df610c2fd" />
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_df90ad87-bf20-45e5-a75d-a5df84384e0e" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/ACDCConverter.targetPpcc" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#ACDCConverter.targetPpcc" />
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.mRID>4285c664-8cb0-4013-826f-347c64ed554b</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>RegHvdcAbsolute_e468e6ca-8776-4c22-8f9b-390df610c2fd-</cim:IdentifiedObject.name>

--- a/Instance/Espheim/NetworkCode/cimxml/Espheim_RA.xml
+++ b/Instance/Espheim/NetworkCode/cimxml/Espheim_RA.xml
@@ -142,7 +142,7 @@
   </nc:GridStateAlterationRemedialAction>
   <nc:RegulatingControlAction rdf:ID="_12b9a70c-9e72-4ec5-af01-d32d440c2aa3">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_c9c76af9-c11e-49ad-854c-760292b59a6e"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/RegulatingControl.targetValue"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControl.targetValue"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>Preventive RA: RegulatingControlAction on a PST, tap=2</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>12b9a70c-9e72-4ec5-af01-d32d440c2aa3</cim:IdentifiedObject.mRID>
@@ -151,7 +151,7 @@
   </nc:RegulatingControlAction>
   <nc:TapPositionAction rdf:ID="_dbad8bad-94a9-428a-a8d6-ef6f48490e6d">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_2e4f4212-7b30-4316-9fce-ca618f2a8a05"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/TapChanger.step"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#TapChanger.step"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>Curative RA: TapPositionAction (Tap position = 1)</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>dbad8bad-94a9-428a-a8d6-ef6f48490e6d</cim:IdentifiedObject.mRID>
@@ -160,7 +160,7 @@
   </nc:TapPositionAction>
   <nc:TapPositionAction rdf:ID="_9a7f821b-8eb8-4c0a-a67e-25e4d5aeaa8d">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_5898c268-9b32-4ab5-9cfc-64546135a337"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/TapChanger.step"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#TapChanger.step"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>This is an example of tap position action</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>9a7f821b-8eb8-4c0a-a67e-25e4d5aeaa8d</cim:IdentifiedObject.mRID>
@@ -169,7 +169,7 @@
   </nc:TapPositionAction>
   <nc:TopologyAction rdf:ID="_b66ddbf5-1314-444e-91bc-26c09bc9c656">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_c8bf6b19-1c3b-4ce6-a15c-99995a3c88ce"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>Curative RA: TopologyAction (generator trip)</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>b66ddbf5-1314-444e-91bc-26c09bc9c656</cim:IdentifiedObject.mRID>
@@ -178,7 +178,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_4d3757fd-b40a-4d7b-be47-6553935234ff">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_d856a2a2-3de4-4a7b-aea4-d363c13d9014"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>Curative RA: TopologyAction (generator trip)</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>4d3757fd-b40a-4d7b-be47-6553935234ff</cim:IdentifiedObject.mRID>
@@ -187,7 +187,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_dc8f7d4a-9b37-4143-ab12-cc4e554460ce">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_fb487cc2-0f7b-4958-8f66-1d3fabf7840d"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>Curative RA: TopologyAction (transformer trip)</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>dc8f7d4a-9b37-4143-ab12-cc4e554460ce</cim:IdentifiedObject.mRID>
@@ -196,7 +196,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_99e03961-06a8-485e-8c6e-fd833835c00a">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_1fd630a9-b9d8-414b-ac84-b47a093af936"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>Curative RA: TopologyAction (wind generator trip)</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>99e03961-06a8-485e-8c6e-fd833835c00a</cim:IdentifiedObject.mRID>

--- a/Instance/Galia/NetworkCode/cimxml/Galia_RA.xml
+++ b/Instance/Galia/NetworkCode/cimxml/Galia_RA.xml
@@ -53,7 +53,7 @@
   </nc:GridStateAlterationRemedialAction>
   <nc:LoadAction rdf:ID="_7bbb3343-e48b-42dd-9ca5-6ff8945ca5b0">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_f4d57bc2-1cef-46ab-ae13-3ad864813d9c"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/EnergyConsumer.p"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#EnergyConsumer.p"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <nc:GridStateAlteration.timePerStage>PT1S</nc:GridStateAlteration.timePerStage>
     <cim:IdentifiedObject.description>Curative RA: LoadAction (30 percent load shed)</cim:IdentifiedObject.description>

--- a/Instance/Svedala/NetworkCode/cimxml/Svedala_RA.xml
+++ b/Instance/Svedala/NetworkCode/cimxml/Svedala_RA.xml
@@ -195,7 +195,7 @@
   </nc:GridStateAlterationRemedialAction>
   <nc:RegulatingControlAction rdf:ID="_4ab66db6-53a4-4ebf-af6e-1ea32b6e77bb">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_b5f07ec3-3a3c-49ec-8e85-02a77d4f79c1"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/RegulatingControl.targetValue"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControl.targetValue"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>RA for generator ID d4e4911b-d87a-4fd5-a7a7-0346c0538db3</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>4ab66db6-53a4-4ebf-af6e-1ea32b6e77bb</cim:IdentifiedObject.mRID>
@@ -204,7 +204,7 @@
   </nc:RegulatingControlAction>
   <nc:RegulatingControlAction rdf:ID="_54174158-33fb-43ad-9c2d-e733165c3acb">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_68255abc-9164-4e9a-89ae-d8c44cf3b2b3"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/RegulatingControl.targetValue"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControl.targetValue"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>RA for Generator ID: _fc77b8f5-555e-4990-b913-a71852ddbfb2</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>54174158-33fb-43ad-9c2d-e733165c3acb</cim:IdentifiedObject.mRID>
@@ -271,7 +271,7 @@
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.normalValue>1.0</nc:RangeConstraint.normalValue>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
   </nc:StaticPropertyRange>
   <nc:StaticPropertyRange rdf:ID="_bc460391-dcc1-4ad1-a54c-c6a55f947582">
     <cim:IdentifiedObject.description>NCP 386</cim:IdentifiedObject.description>
@@ -281,7 +281,7 @@
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.normalValue>1.0</nc:RangeConstraint.normalValue>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
   </nc:StaticPropertyRange>
   <nc:StaticPropertyRange rdf:ID="_77dae0e6-4c18-4318-83c5-292b60179af1">
     <cim:IdentifiedObject.description>NCP 386</cim:IdentifiedObject.description>
@@ -291,7 +291,7 @@
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.normalValue>1.0</nc:RangeConstraint.normalValue>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
   </nc:StaticPropertyRange>
   <nc:StaticPropertyRange rdf:ID="_00c3d990-7241-4275-8013-7482db3ab05b">
     <cim:IdentifiedObject.description>NCP 386</cim:IdentifiedObject.description>
@@ -301,7 +301,7 @@
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.normalValue>1.0</nc:RangeConstraint.normalValue>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
   </nc:StaticPropertyRange>
   <nc:StaticPropertyRange rdf:ID="_7e29e44b-85b3-4e93-9e35-00b76f98e9fc">
     <cim:IdentifiedObject.description>NCP 386</cim:IdentifiedObject.description>
@@ -311,7 +311,7 @@
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.normalValue>1.0</nc:RangeConstraint.normalValue>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
   </nc:StaticPropertyRange>
   <nc:StaticPropertyRange rdf:ID="_f93388e1-20ec-4643-8952-adfb1c93c6f8">
     <cim:IdentifiedObject.description>NCP 386</cim:IdentifiedObject.description>
@@ -321,7 +321,7 @@
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.normalValue>1.0</nc:RangeConstraint.normalValue>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
   </nc:StaticPropertyRange>
   <nc:StaticPropertyRange rdf:ID="_445032fc-0efa-4f5c-b36f-333bc2132e68">
     <cim:IdentifiedObject.description>NCP 386</cim:IdentifiedObject.description>
@@ -331,7 +331,7 @@
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.normalValue>1.0</nc:RangeConstraint.normalValue>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
   </nc:StaticPropertyRange>
   <nc:StaticPropertyRange rdf:ID="_68316fda-bac0-4c4c-8f91-d7a43153454f">
     <cim:IdentifiedObject.description>NCP 386</cim:IdentifiedObject.description>
@@ -341,11 +341,11 @@
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.normalValue>1.0</nc:RangeConstraint.normalValue>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
   </nc:StaticPropertyRange>
   <nc:StaticVarCompensatorAction rdf:ID="_457f111e-43ce-4368-923e-11457cb694f9">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_bf8157d8-d787-44f7-a997-751e50e69165"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/StaticVarCompensator.q"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#StaticVarCompensator.q"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>exemple of static VAR compensator action 1</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>457f111e-43ce-4368-923e-11457cb694f9</cim:IdentifiedObject.mRID>
@@ -354,7 +354,7 @@
   </nc:StaticVarCompensatorAction>
   <nc:TopologyAction rdf:ID="_4b1410d4-3958-4a8c-8289-b3d6b57cfc65">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_d9bd3aaf-cda3-4b54-bb2e-b03dd9925817"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>description</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>4b1410d4-3958-4a8c-8289-b3d6b57cfc65</cim:IdentifiedObject.mRID>
@@ -363,7 +363,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_1dd4c309-ed8b-4bb6-a26d-4888b8e1f009">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_b2555ccc-6562-4887-8abc-19a6e51cfe36"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>Preventive RA: TopologyAction (load trip)</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>1dd4c309-ed8b-4bb6-a26d-4888b8e1f009</cim:IdentifiedObject.mRID>
@@ -372,7 +372,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_fe13b0ad-0f87-45d8-a96f-93fdfc33c50b">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_7e422768-207d-455f-976e-0b1cb2338509"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.maximumPerDay>5</nc:GridStateAlteration.maximumPerDay>
     <nc:GridStateAlteration.minimumActivation>PT1H</nc:GridStateAlteration.minimumActivation>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
@@ -384,7 +384,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_26e73fc0-82d0-4b6a-929d-1bb2c49a24d5">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_7e422768-207d-455f-976e-0b1cb2338509"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.maximumPerDay>5</nc:GridStateAlteration.maximumPerDay>
     <nc:GridStateAlteration.minimumActivation>PT1H</nc:GridStateAlteration.minimumActivation>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
@@ -396,7 +396,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_eb60d1c0-8bcc-463b-8b91-8dc1833b2a92">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_fa3e3533-345a-4ef1-a46d-3ab6d251924a"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.maximumPerDay>5</nc:GridStateAlteration.maximumPerDay>
     <nc:GridStateAlteration.minimumActivation>PT1H</nc:GridStateAlteration.minimumActivation>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
@@ -408,7 +408,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_55961174-efb4-44be-8832-b0fb107de235">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_fa3e3533-345a-4ef1-a46d-3ab6d251924a"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.maximumPerDay>5</nc:GridStateAlteration.maximumPerDay>
     <nc:GridStateAlteration.minimumActivation>PT1H</nc:GridStateAlteration.minimumActivation>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
@@ -420,7 +420,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_889535e6-2789-46e7-8ba7-da7be9951914">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_d9bd3aaf-cda3-4b54-bb2e-b03dd9925817"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>description</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>889535e6-2789-46e7-8ba7-da7be9951914</cim:IdentifiedObject.mRID>
@@ -430,7 +430,7 @@
   <nc:TopologyAction rdf:ID="_55a11475-e39f-4541-accc-d979376bcda3">
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_8739648b-662d-46c1-9f51-2965398e6ded"/>
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_347f4f7e-a2b6-4880-846a-8bd1effb00d5"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>description</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>55a11475-e39f-4541-accc-d979376bcda3</cim:IdentifiedObject.mRID>
@@ -439,7 +439,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_1d19ef52-6ed4-4167-aa00-c3deb0ea0005">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_7e422768-207d-455f-976e-0b1cb2338509"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.maximumPerDay>5</nc:GridStateAlteration.maximumPerDay>
     <nc:GridStateAlteration.minimumActivation>PT1H</nc:GridStateAlteration.minimumActivation>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
@@ -451,7 +451,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_516cbe68-560d-48ce-8745-f84b90aef2c5">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_cfabf356-c5e1-4391-b91b-3330bc24f0c9"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>Preventive RA : substation split</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>516cbe68-560d-48ce-8745-f84b90aef2c5</cim:IdentifiedObject.mRID>
@@ -460,7 +460,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_bd7aaf12-e6b9-44ef-9e04-3d2992581718">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_587cb391-ed16-4a1d-876e-f90241addce5"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>description</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>bd7aaf12-e6b9-44ef-9e04-3d2992581718</cim:IdentifiedObject.mRID>
@@ -469,7 +469,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_d316a138-5b75-4a80-bd95-151adfbfe13d">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_7e422768-207d-455f-976e-0b1cb2338509"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.maximumPerDay>5</nc:GridStateAlteration.maximumPerDay>
     <nc:GridStateAlteration.minimumActivation>PT1H</nc:GridStateAlteration.minimumActivation>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
@@ -481,7 +481,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_beee0b9b-588d-4efc-9972-cd4cd25b0b70">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_5e401955-387e-45ce-b126-dd142b06b20c"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
     <cim:IdentifiedObject.description>description</cim:IdentifiedObject.description>
     <cim:IdentifiedObject.mRID>beee0b9b-588d-4efc-9972-cd4cd25b0b70</cim:IdentifiedObject.mRID>
@@ -490,7 +490,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_615cdd6e-88f3-4e32-a396-766e171170eb">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_fa3e3533-345a-4ef1-a46d-3ab6d251924a"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.maximumPerDay>5</nc:GridStateAlteration.maximumPerDay>
     <nc:GridStateAlteration.minimumActivation>PT1H</nc:GridStateAlteration.minimumActivation>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
@@ -502,7 +502,7 @@
   </nc:TopologyAction>
   <nc:TopologyAction rdf:ID="_c33f19fd-ed90-4440-a5f8-5b62d1cc559e">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_fa3e3533-345a-4ef1-a46d-3ab6d251924a"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.maximumPerDay>5</nc:GridStateAlteration.maximumPerDay>
     <nc:GridStateAlteration.minimumActivation>PT1H</nc:GridStateAlteration.minimumActivation>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
@@ -533,7 +533,7 @@
   </nc:GridStateAlterationRemedialAction>
   <nc:TopologyAction rdf:ID="_b61d5cd5-0373-4e58-82c3-b5e4d86147a5">
     <nc:GridStateAlteration.GridStateAlterationRemedialAction rdf:resource="#_6d2c8901-d068-4d22-8ce9-7379644b4f17"/>
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:GridStateAlteration.maximumPerDay>5</nc:GridStateAlteration.maximumPerDay>
     <nc:GridStateAlteration.minimumActivation>PT1H</nc:GridStateAlteration.minimumActivation>
     <nc:GridStateAlteration.normalEnabled>true</nc:GridStateAlteration.normalEnabled>
@@ -551,7 +551,7 @@
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.normalValue>0.0</nc:RangeConstraint.normalValue>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
   </nc:StaticPropertyRange>
 
 <!-- UC_7 Automatic Generation Shedding -->
@@ -593,7 +593,7 @@
   </nc:GridStateAlterationCollection>
   <nc:TopologyAction rdf:ID="_e2a19b7e-6d21-4987-b138-f746bba325e6">
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_332b7627-e0ad-4bd5-a678-aebb305727a6" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open" />
     <cim:IdentifiedObject.mRID>e2a19b7e-6d21-4987-b138-f746bba325e6</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Generator HÄLLAN_G1 breaker CT72_G1-S OPEN</cim:IdentifiedObject.name>
     <nc:TopologyAction.Switch rdf:resource="#_ecc7d452-3cc6-4a6f-ac55-cfc80f3aac53" />
@@ -604,7 +604,7 @@
     <nc:RangeConstraint.GridStateAlteration rdf:resource="#_e2a19b7e-6d21-4987-b138-f746bba325e6"/>
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:RangeConstraint.normalValue>1</nc:RangeConstraint.normalValue>
   </nc:StaticPropertyRange> 
   <nc:StageTrigger rdf:ID="_b6617e31-c8f1-4e44-b157-d630948695f1">
@@ -629,7 +629,7 @@
   </nc:GridStateAlterationCollection>
   <nc:TopologyAction rdf:ID="_d101c17c-c67a-4a33-b8ad-aaee4ca6563e">
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_124a56f0-22cc-47b0-a9ab-219641b76e25" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open" />
     <cim:IdentifiedObject.mRID>d101c17c-c67a-4a33-b8ad-aaee4ca6563e</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Generator HÄLLAN_G3 breaker CT72_G3-S OPEN</cim:IdentifiedObject.name>
     <nc:TopologyAction.Switch rdf:resource="#_dafeb217-8a10-4068-b88a-2e884a2bdc32" />
@@ -640,7 +640,7 @@
     <nc:RangeConstraint.GridStateAlteration rdf:resource="#_d101c17c-c67a-4a33-b8ad-aaee4ca6563e"/>
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:RangeConstraint.normalValue>1</nc:RangeConstraint.normalValue>
   </nc:StaticPropertyRange> 
   <nc:StageTrigger rdf:ID="_958419bd-309d-4946-bf90-b4ce1819b3c7">
@@ -665,7 +665,7 @@
   </nc:GridStateAlterationCollection>
   <nc:RotatingMachineAction rdf:ID="_884fd5ca-afa6-4b5b-a0f7-2daee3f1959f">
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_b7a0d8df-2809-4bd3-952c-474ba032aa46" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/RotatingMachine.p" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#RotatingMachine.p" />
     <cim:IdentifiedObject.mRID>884fd5ca-afa6-4b5b-a0f7-2daee3f1959f</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Set generator HÄLLAN_G3 power to Pmin</cim:IdentifiedObject.name>
     <nc:RotatingMachineAction.RotatingMachine rdf:resource="#_2a35657f-a1a8-45dc-911e-e71535b35d87" />
@@ -676,7 +676,7 @@
     <nc:RangeConstraint.GridStateAlteration rdf:resource="#_884fd5ca-afa6-4b5b-a0f7-2daee3f1959f"/>
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/RotatingMachine.p"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#RotatingMachine.p"/>
     <nc:RangeConstraint.normalValue>-10</nc:RangeConstraint.normalValue>
   </nc:StaticPropertyRange>
   <nc:StageTrigger rdf:ID="_011fd5e3-cdcb-46d6-b6b8-a81f9fac8b59">
@@ -792,7 +792,7 @@
   </nc:GridStateAlterationCollection>
   <nc:RotatingMachineAction rdf:ID="_8e60eea4-9c86-4e9d-8012-6645d5efb96d">
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_02a420c3-dcc2-413e-9f7d-a4997c42e155" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/RotatingMachine.p" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#RotatingMachine.p" />
     <cim:IdentifiedObject.mRID>8e60eea4-9c86-4e9d-8012-6645d5efb96d</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Set generator HÄLLAN_G3 power to Pmin</cim:IdentifiedObject.name>
     <nc:RotatingMachineAction.RotatingMachine rdf:resource="#_2a35657f-a1a8-45dc-911e-e71535b35d87" />
@@ -803,7 +803,7 @@
     <nc:RangeConstraint.GridStateAlteration rdf:resource="#_8e60eea4-9c86-4e9d-8012-6645d5efb96d"/>
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/RotatingMachine.p"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#RotatingMachine.p"/>
     <nc:RangeConstraint.normalValue>-10</nc:RangeConstraint.normalValue>
   </nc:StaticPropertyRange>
   <nc:StageTrigger rdf:ID="_92195218-f3a3-4cca-af38-1550a91bcd44">
@@ -828,7 +828,7 @@
   </nc:GridStateAlterationCollection>
   <nc:TopologyAction rdf:ID="_0bec00cd-cf46-40d8-931a-efb35bc417af">
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_12097f09-e5cc-4fdc-98eb-0675d0f2af11" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open" />
     <cim:IdentifiedObject.mRID>0bec00cd-cf46-40d8-931a-efb35bc417af</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Generator HÄLLAN_G1 breaker CT72_G1-S OPEN</cim:IdentifiedObject.name>
     <nc:TopologyAction.Switch rdf:resource="#_ecc7d452-3cc6-4a6f-ac55-cfc80f3aac53" />
@@ -839,7 +839,7 @@
     <nc:RangeConstraint.GridStateAlteration rdf:resource="#_0bec00cd-cf46-40d8-931a-efb35bc417af"/>
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:RangeConstraint.normalValue>1</nc:RangeConstraint.normalValue>
   </nc:StaticPropertyRange> 
   <nc:StageTrigger rdf:ID="_9aaa5e63-3126-4f9d-930a-2397b97af9d5">
@@ -879,7 +879,7 @@
   </nc:GridStateAlterationCollection>
   <nc:TopologyAction rdf:ID="_0725050a-0ece-49d0-8822-f5e0c8fb99c9">
     <nc:GridStateAlteration.GridStateAlterationCollection rdf:resource="#_ea6979c2-2ad4-484a-9f41-bec157a0eedd" />
-    <nc:GridStateAlteration.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open" />
+    <nc:GridStateAlteration.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open" />
     <cim:IdentifiedObject.mRID>0725050a-0ece-49d0-8822-f5e0c8fb99c9</cim:IdentifiedObject.mRID>
     <cim:IdentifiedObject.name>Generator HÄLLAN_G1 breaker CT72_G3-S OPEN</cim:IdentifiedObject.name>
     <nc:TopologyAction.Switch rdf:resource="#_dafeb217-8a10-4068-b88a-2e884a2bdc32" />
@@ -890,7 +890,7 @@
     <nc:RangeConstraint.GridStateAlteration rdf:resource="#_0725050a-0ece-49d0-8822-f5e0c8fb99c9"/>
     <nc:RangeConstraint.direction rdf:resource="https://cim4.eu/ns/nc#RelativeDirectionKind.none"/>
     <nc:RangeConstraint.valueKind rdf:resource="https://cim4.eu/ns/nc#ValueOffsetKind.absolute"/>
-    <nc:StaticPropertyRange.PropertyReference rdf:resource="https://energy.referencedata.eu/PropertyReference/Switch.open"/>
+    <nc:StaticPropertyRange.PropertyReference rdf:resource="http://iec.ch/TC57/CIM100#Switch.open"/>
     <nc:RangeConstraint.normalValue>1</nc:RangeConstraint.normalValue>
   </nc:StaticPropertyRange> 
   <nc:StageTrigger rdf:ID="_e5d8b062-b39b-4fea-b329-a2781b8fbac8">

--- a/buildScripts/validate_relicap.py
+++ b/buildScripts/validate_relicap.py
@@ -48,8 +48,15 @@ if not dangling.empty:
     # Add file data
     dangling = dangling.merge(filename_mapping, left_on='INSTANCE_ID_FROM', right_on='INSTANCE_ID', how='left').drop(columns=['INSTANCE_ID'])
 
-    # Filter out valid missing references
-    dangling = dangling[dangling['KEY_FROM'] != 'Model.Supersedes']
+    # Filter out valid missing references. PropertyReference targets external
+    # CIM/nc ontology properties (issue #358), which resolve outside the instance
+    # data and are not dangling references.
+    to_ignore = [
+        'Model.Supersedes',
+        'GridStateAlteration.PropertyReference',
+        'StaticPropertyRange.PropertyReference',
+    ]
+    dangling = dangling[~dangling['KEY_FROM'].isin(to_ignore)]
 
     # Details
     dangling[['ID_FROM', 'KEY_FROM', 'VALUE_FROM', 'Filename']].to_csv(REPORT_DIR / "dangling_references_detailed.csv", index=False)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -49,8 +49,11 @@ def test_dangling_references(grid_data):
         # Filter out valid missing references or references to profiles not loaded
         to_ignore = [
             'Model.Supersedes',
-            #'GridStateAlteration.PropertyReference',
-            #'StaticPropertyRange.PropertyReference',
+            # PropertyReference now targets external CIM/nc ontology properties
+            # (e.g. http://iec.ch/TC57/CIM100#RotatingMachine.p, issue #358), which
+            # resolve outside the instance data and are not dangling references.
+            'GridStateAlteration.PropertyReference',
+            'StaticPropertyRange.PropertyReference',
         ]
         dangling = dangling[~dangling['KEY_FROM'].isin(to_ignore)]
 


### PR DESCRIPTION
Closes #358.

## What
Replaces the `energy.referencedata.eu/PropertyReference/<X>` reference-data catalogue URLs with the canonical **CIM17** (`http://iec.ch/TC57/CIM100#<X>`) property URIs, for both `nc:GridStateAlteration.PropertyReference` and `nc:StaticPropertyRange.PropertyReference`.

- **75 references across 5 `*_RA.xml` files** (Svedala 40, Belgovia 19, DC-Espheim-Svedala 8, Espheim 7, Galia 1).
- All 9 distinct properties (`Switch.open`, `RotatingMachine.p`, `ACDCConverter.targetPpcc`, `TapChanger.step`, `EquivalentInjection.p`, `RegulatingControl.targetValue`, `StaticVarCompensator.q`, `ShuntCompensator.sections`, `EnergyConsumer.p`) exist in the CIM100 namespace per `PropertyReference-ReferenceData_v5-0-0.xml` — none are nc-only.
- Other `energy.referencedata.eu` URLs (publisher, spatial, isVersionOf, etc.) are untouched; all files remain well-formed XML.

## Validation change
These associations now resolve to **external CIM ontology properties**, not instance data, so they are no longer instance-internal references. This PR **activates the pre-staged (previously commented-out) PropertyReference ignore entries** in `tests/test_validation.py` and mirrors the same two keys in `buildScripts/validate_relicap.py`. Reviewer note: please confirm this matches the intended team consensus per the CLAUDE.md dangling-filter caution.

## Out of scope
There is a **pre-existing, unrelated** dangling-reference failure — 9 `Model.DependentOn` refs in `Instance/Jotunheim/Grid/cimxml/20220615T2230Z_2D_Jotunheim_TP_2.xml` — present on the base branch and left untouched here.

## Follow-up
Per the issue, the same change is to be applied on `cgmes-3.0_ncp-2.5_tc-2.0` after this merges (separate PR), re-verifying each property against the reference data on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)