### PR TITLE
Include Jotunheim ChangeSet SSH files in the CGM zip (issue #361)

### DIFF
--- a/buildScripts/create_cgm_zip.py
+++ b/buildScripts/create_cgm_zip.py
@@ -4,7 +4,8 @@ Create a zip package for CGM (Common Grid Model) import from the ReliCapGrid rep
 CGM package contents (per README):
   Grid:
     - EQ profile from each TSO's Instance/<TSO>/Grid/cimxml/ folder
-    - All files from Instance/Jotunheim/Grid/cimxml/ (SSH, TP, SV)
+    - All files from Instance/Jotunheim/Grid/cimxml/ (TP, SV)
+    - RCC-updated per-IGM SSH files from Instance/Jotunheim/ChangeSet/cimxml/
     - All boundary files from Instance/boundaryData/Grid/cimxml/
     - All files from Instance/commonData/Grid/cimxml/
   Network Code Profiles (optional, --ncp flag):
@@ -53,6 +54,17 @@ def collect_cgm_files(instance_dir: Path, tsos: list[str], include_ncp: bool) ->
         missing.append(f"Jotunheim Grid cimxml dir not found: {jotunheim_dir}")
     else:
         for f in sorted(jotunheim_dir.glob("*.xml")):
+            entries.append((f, f.name))
+
+    # SSH files from Jotunheim/ChangeSet/cimxml (RCC-updated per-IGM SSH for the CGM)
+    changeset_dir = instance_dir / "Jotunheim" / "ChangeSet" / "cimxml"
+    if not changeset_dir.exists():
+        missing.append(f"Jotunheim ChangeSet cimxml dir not found: {changeset_dir}")
+    else:
+        ssh_files = sorted(changeset_dir.glob("*_SSH_*.xml"))
+        if not ssh_files:
+            missing.append(f"No SSH files found in: {changeset_dir}")
+        for f in ssh_files:
             entries.append((f, f.name))
 
     # All boundary files


### PR DESCRIPTION
Part of #361 (v2.4 branch).

## What
`collect_cgm_files` in `buildScripts/create_cgm_zip.py` collected the RCC grid files from `Jotunheim/Grid/cimxml/` (only **TP + SV**) but never the per-IGM updated **SSH_2** files in `Jotunheim/ChangeSet/cimxml/`. As a result the CGM package shipped **without the SSH profile**, and the CGM TP's 9 `md:Model.DependentOn` references appeared as **dangling** in validation (their target models were never loaded).

This adds a block to collect `Instance/Jotunheim/ChangeSet/cimxml/*_SSH_*.xml`, matching the pattern of the sibling blocks (flat archive name, `missing` warning on absent dir). Docstring updated.

## Verification
- `python buildScripts/create_cgm_zip.py` now emits the 9 `*_SSH_2.xml` ChangeSet files (Belgovia, Britheim, Espheim, Galia, HVDC Espheim-Svedala, HVDC Nordheim-Galia, Nordheim, Portheim, Svedala) — confirmed present in the built zip.
- `test_dangling_references`: the 9 `Model.DependentOn` refs are gone, **no new dangling refs** introduced. (The 75 `PropertyReference` refs still reported on this branch are unrelated and fixed by #360.)

## Follow-up
Same fix for `cgmes-3.0_ncp-2.5_tc-2.0` in a separate PR (tracked by #361).

🤖 Generated with [Claude Code](https://claude.com/claude-code)