### PR TITLE
PROF-driven SHACL + schema validation with code scanning integration (#381)

### DIFF
--- a/.github/workflows/shacl_validation.yml
+++ b/.github/workflows/shacl_validation.yml
@@ -1,0 +1,81 @@
+name: SHACL validation (PROF-driven)
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - Instance/**
+      - buildScripts/validate_instances.py
+      - buildScripts/prof_map.py
+      - .github/workflows/shacl_validation.yml
+      - pyproject.toml
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  shacl-validation:
+    name: Validate all instances via PROF-mapped SHACL
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout application profiles library (CGMES 3.0, main)
+        uses: actions/checkout@v4
+        with:
+          repository: entsoe/application-profiles-library
+          ref: main
+          path: .apl-main
+
+      - name: Checkout application profiles library (NCP 2.4)
+        uses: actions/checkout@v4
+        with:
+          repository: entsoe/application-profiles-library
+          ref: ncp-v2-4-2
+          path: .apl-ncp24
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Validate instances, export SARIF + SHACL reports
+        run: uv run buildScripts/validate_instances.py --apl cgmes-3.0=.apl-main --apl ncp-2.4=.apl-ncp24
+
+      # one upload per SARIF run — code scanning does not combine
+      # multiple runs uploaded under the same category
+      - name: Upload CGMES 3.0 SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: reports/shacl-cgmes-3.0.sarif
+          category: shacl-cgmes-3.0
+
+      - name: Upload NCP 2.4 SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: reports/shacl-ncp-2.4.sarif
+          category: shacl-ncp-2.4
+
+      - name: Upload CGMES 3.0 schema-conformance SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: reports/schema-cgmes-3.0.sarif
+          category: schema-cgmes-3.0
+
+      - name: Upload NCP 2.4 schema-conformance SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: reports/schema-ncp-2.4.sarif
+          category: schema-ncp-2.4
+
+      - name: Upload SARIF + full SHACL reports as run artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: shacl-reports
+          path: |
+            reports/shacl-*.sarif
+            reports/schema-*.sarif
+            reports/*-shacl-report.*
+            reports/summary.md
+
+      - name: Run summary with link to code scanning results
+        run: cat reports/summary.md >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,20 @@
 /.idea
 *.iml
 validation_report/
+.shacl_cache/
 
 # Python bytecode cache #
 ############
 tests\__pycache__
 *.pyc
+
+# APL checkouts for SHACL validation #
+############
+.apl-main/
+.apl-ncp24/
+
+# generated validation reports (CI run artifacts) #
+############
+reports/*.sarif
+reports/*-shacl-report.*
+reports/summary.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,10 @@ Instance/
   referenceData/
 
 buildScripts/
-  create_cgm_zip.py    # Assembles CGM import zip packages
-  validate_relicap.py  # Runs dangling-reference validation, writes CSV reports
+  create_cgm_zip.py       # Assembles CGM import zip packages
+  validate_relicap.py     # Dangling-reference / duplicate-ID / UUID checks, writes CSV reports
+  prof_map.py             # DX-PROF descriptors -> SHACL shape paths (used by validate_instances)
+  validate_instances.py   # SHACL + schema validation of all instance files (PROF-driven, CI)
 
 tests/
   test_validation.py   # pytest suite: dangling refs, duplicate IDs, UUID format
@@ -125,7 +127,18 @@ regenerates the manifests of the model folders that PR touched and opens its own
 so approve it yourself or ask a maintainer. Manual full regeneration is still available via
 the workflow's `Run workflow` button, which opens `auto/manifests-manual-<run-id>`.
 
-### Running Validation (full report)
+### Running Validation
+
+SHACL + schema conformance of every instance file (what CI runs, see
+`.github/workflows/shacl_validation.yml`; needs two application-profiles-library
+checkouts):
+
+```bash
+uv run buildScripts/validate_instances.py --apl cgmes-3.0=.apl-main --apl ncp-2.4=.apl-ncp24
+# SARIF + sh:ValidationReports + summary.md written to reports/
+```
+
+Dangling-reference / duplicate-ID / UUID checks (separate, tabular):
 
 ```bash
 python buildScripts/validate_relicap.py

--- a/buildScripts/prof_map.py
+++ b/buildScripts/prof_map.py
@@ -1,0 +1,115 @@
+"""Map profile URIs to SHACL shape files via the DX-PROF descriptors of the
+ENTSO-E application-profiles-library (APL).
+
+An instance file declares its profile as `md:Model.profile` (CGMES) or
+`dcterms:conformsTo` (NC). Each APL PROF descriptor carries the matching keys
+(`rdf:about`, `owl:versionIRI`, `owl:priorVersion`) and, per resource, the
+role and artifact. Only `role/constraints` resources that conform to SHACL are
+returned; artifacts are resolved by basename against `<family>/SHACL/` then
+`<family>/RDFS/` (CGMES artifacts are bare filenames, NCP ones absolute URLs —
+neither resolves as a relative URI).
+
+Debug CLI:  python buildScripts/prof_map.py <apl_dir>
+"""
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from urllib.parse import urlparse
+
+import pandas
+import triplets  # noqa: F401  (registers pandas.read_RDF)
+
+ROLE_CONSTRAINTS = "role/constraints"
+SHACL_MARK = "http://www.w3.org/ns/shacl"
+
+
+@dataclass
+class ProfileShapes:
+    prof_file: str
+    family: str                                # "CGMES" | "NCP"
+    keys: set = field(default_factory=set)     # about + versionIRI + priorVersion URIs
+    shacl_paths: list = field(default_factory=list)
+    missing_artifacts: list = field(default_factory=list)
+
+
+def _artifact_basename(value):
+    return PurePosixPath(urlparse(str(value)).path).name
+
+
+def _resolve_artifact(apl_dir, family, basename):
+    for subdir in ("SHACL", "RDFS"):
+        candidate = apl_dir / family / subdir / basename
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def build_prof_map(apl_dir):
+    """Return ({key_uri: ProfileShapes}, gap_messages) for one APL checkout."""
+    apl_dir = Path(apl_dir)
+    prof_files = sorted(path for family in ("CGMES", "NCP") for path in apl_dir.glob(f"{family}/PROF/*.rdf"))
+    if not prof_files:
+        return {}, [f"no PROF files under {apl_dir}/(CGMES|NCP)/PROF"]
+
+    data = pandas.read_RDF([str(p) for p in prof_files])
+    by_basename = {p.name: p for p in prof_files}
+
+    prof_map, gaps = {}, []
+    for instance_id, rows in data.groupby("INSTANCE_ID"):
+        labels = rows.loc[rows["KEY"] == "label", "VALUE"]
+        source = next((by_basename[Path(v).name] for v in labels if Path(v).name in by_basename), None)
+        if source is None:
+            continue
+        family = source.parent.parent.name
+
+        profile_nodes = rows.loc[(rows["KEY"] == "type") & rows["VALUE"].str.endswith("Profile"), "ID"]
+        if profile_nodes.empty:
+            gaps.append(f"{source.name}: no prof:Profile node")
+            continue
+        profile_id = profile_nodes.iloc[0]
+
+        keys = set(rows.loc[rows["KEY"].isin(["versionIRI", "priorVersion"]), "VALUE"])
+        if str(profile_id).startswith("http"):
+            keys.add(str(profile_id))
+
+        profile = ProfileShapes(prof_file=str(source), family=family, keys=keys)
+
+        descriptor_ids = set(rows.loc[(rows["ID"] == profile_id) & (rows["KEY"] == "hasResource"), "VALUE"])
+        for descriptor in descriptor_ids:
+            desc_rows = rows[rows["ID"] == descriptor]
+            role = desc_rows.loc[desc_rows["KEY"] == "hasRole", "VALUE"]
+            conforms = desc_rows.loc[desc_rows["KEY"] == "conformsTo", "VALUE"]
+            if not role.str.endswith(ROLE_CONSTRAINTS).any() or not (conforms == SHACL_MARK).any():
+                continue
+            for artifact in desc_rows.loc[desc_rows["KEY"] == "hasArtifact", "VALUE"]:
+                resolved = _resolve_artifact(apl_dir, family, _artifact_basename(artifact))
+                if resolved is None:
+                    profile.missing_artifacts.append(_artifact_basename(artifact))
+                else:
+                    profile.shacl_paths.append(resolved)
+
+        profile.shacl_paths = sorted(set(profile.shacl_paths))
+        if not profile.shacl_paths:
+            gaps.append(f"{source.name}: no resolvable constraints-role SHACL artifacts")
+        gaps.extend(f"{source.name}: artifact not found: {name}" for name in profile.missing_artifacts)
+
+        for key in profile.keys:
+            prof_map[key] = profile
+
+    return prof_map, gaps
+
+
+if __name__ == "__main__":
+    import sys
+
+    prof_map, gaps = build_prof_map(sys.argv[1])
+    profiles = {id(p): p for p in prof_map.values()}
+    print(f"{len(profiles)} profiles, {len(prof_map)} match keys")
+    for profile in sorted(profiles.values(), key=lambda p: p.prof_file):
+        print(f"\n{Path(profile.prof_file).name} [{profile.family}]")
+        for key in sorted(profile.keys):
+            print(f"  key: {key}")
+        for path in profile.shacl_paths:
+            print(f"  shacl: {path.name}")
+    if gaps:
+        print("\nGaps:")
+        print("\n".join(f"  {g}" for g in gaps))

--- a/buildScripts/validate_instances.py
+++ b/buildScripts/validate_instances.py
@@ -1,0 +1,381 @@
+"""PROF-driven SHACL + schema validation of all CGMES and NC instance files.
+
+Instance files map to shape sets via the DX-PROF descriptors of the
+application-profiles-library (prof_map.py), grouped so cross-file references
+resolve, and validated in two passes: counting constraints per instance file
+(scope=), everything else on the group frame. Schema conformance is a third,
+shapes-independent pass straight from the export schema. Outputs: one grouped
+SARIF per release + layer, full sh:ValidationReports per group, summary.md.
+
+Run:
+    uv run buildScripts/validate_instances.py --apl cgmes-3.0=.apl-main --apl ncp-2.4=.apl-ncp24
+"""
+import argparse
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import quote_plus
+
+import pandas
+import triplets
+from triplets import cgmes_tools
+from triplets.export_schema import schemas
+
+from prof_map import build_prof_map
+
+logging.getLogger("triplets.validation").setLevel(logging.ERROR)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REPORTS = REPO_ROOT / "reports"
+LEVEL_ICONS = {"error": "🔴", "warning": "🟠", "note": "🔵"}
+
+RELEASES = {
+    "cgmes-3.0": {"apl": ".apl-main", "kind": "cgmes", "rdf_map": schemas.ENTSOE_CGMES_3_0_0_552_ED1},
+    "ncp-2.4": {"apl": ".apl-ncp24", "kind": "nc", "rdf_map": schemas.ENTSOE_NC_2_4_1_552_ED1},
+    # "ncp-2.5": add once triplets ships an NC 2.5 export schema (rdf_map)
+    # "cgmes-2.4": add once the APL publishes its PROF + SHACL
+}
+
+# Cross-cutting CGMES shapes referenced by no PROF descriptor (APL gap, filed
+# as application-profiles-library#130)
+CGMES_COMMON_SHACL = [
+    "CGMES/SHACL/61970-600-1_AllProfiles-AP-Con-Complex-SHACL.ttl",
+]
+
+# Near-duplicates of Instance/Jotunheim/GridSituation/cimxml/ (kept dir wins)
+DUPLICATE_GLOB = "Instance/Jotunheim/NetworkCode/*.xml"
+
+# per-dataset semantics — evaluated per instance file, never on the union:
+# counting must not see other files' rdf:about continuation, and each profile's
+# sh:closed AllowedProperties list only applies to datasets of THAT profile
+# (e.g. ssi:OrdinaryContingency-AllowedProperties allows 2 properties; run over
+# a frame with CO data it would reject every legitimate Contingency property)
+PER_DATASET = ("sh:minCount", "sh:maxCount", "sh:closed")
+
+
+@dataclass
+class FileInfo:
+    path: str                 # repo-relative posix
+    instance_id: str
+    kind: str                 # "cgmes" | "nc"
+    profile_uris: list
+    area: str                 # Instance/<area>/...
+
+
+@dataclass
+class Group:
+    name: str
+    files: list               # FileInfo loaded into the frame (incl. context)
+    report_paths: set         # paths whose violations are reported
+    union_shapes: list        # Complex/AllProfiles shapes, run on the group frame
+    dataset_shapes: dict      # instance_id -> [Simple shapes], run with scope=
+    rdf_map: object
+
+
+def scan_instances():
+    """Parse every instance file once; classify by header profile declaration."""
+    everything = sorted(str(p.relative_to(REPO_ROOT)) for p in REPO_ROOT.glob("Instance/**/*.xml"))
+    duplicates = {p for p in everything if Path(p).match(DUPLICATE_GLOB)}
+    files = [p for p in everything if p not in duplicates]
+    skipped = [(p, "duplicate of GridSituation/cimxml") for p in sorted(duplicates)]
+
+    frame = pandas.read_RDF(files, max_workers=os.cpu_count())
+
+    # release routing policy over the header inventory: Model.profile => the
+    # CGMES release, an ap.cim4.eu conformsTo => the NC release
+    headers = cgmes_tools.get_loaded_profiles(frame)
+    headers = headers.assign(path=[str(Path(v).resolve().relative_to(REPO_ROOT)) for v in headers["label"]])
+    cgmes = headers[headers["KEY"] == "Model.profile"]
+    nc = headers[(headers["KEY"] == "conformsTo") & headers["VALUE"].str.startswith("https://ap.cim4.eu/")]
+
+    declared = {}
+    for source, kind in ((cgmes, "cgmes"), (nc, "nc")):
+        for row in source.itertuples():
+            entry = declared.setdefault(str(row.INSTANCE_ID), (row.path, kind, set()))
+            if entry[1] == kind:
+                entry[2].add(row.VALUE)
+    infos = [FileInfo(path, instance_id, kind, sorted(uris), Path(path).parts[1])
+             for instance_id, (path, kind, uris) in sorted(declared.items(), key=lambda kv: kv[1][0])]
+    skipped += [(p, "no application profile declared") for p in files if p not in {fi.path for fi in infos}]
+    return frame, infos, skipped
+
+
+def resolve_shapes(profile_uris, prof_map):
+    """(shape paths, unmapped uris) for a set of declared profile URIs."""
+    shapes, unmapped = set(), []
+    for uri in profile_uris:
+        profile = prof_map.get(uri)
+        if profile is None:
+            unmapped.append(uri)
+        else:
+            shapes.update(profile.shacl_paths)
+    return sorted(shapes), unmapped
+
+
+def is_dataset_shape(path):
+    """Cost filter for the per-file pass: only these files carry counting
+    constraints, so the Complex sh:sparql shapes are not re-run once per
+    instance file. The semantic split is the PER_DATASET type filter."""
+    return "-Con-Simple-" in path.name or path.name == "DatasetMetadata-AP-Con-SHACL.ttl"
+
+
+def drop_boundary(paths):
+    """EquipmentBoundary shapes (bundled into the EQ PROF) constrain Terminal/
+    ConnectivityNode to boundary-legal classes — boundary datasets only."""
+    return [p for p in paths if "EquipmentBoundary" not in p.name]
+
+
+def shape_split(files, prof_map, keep_boundary=False):
+    """(union_shapes, dataset_shapes, unmapped) for a set of reported files.
+
+    union_shapes = everything (reference checks need the full group frame);
+    dataset_shapes = the file's own Simple shapes, re-run per file with scope=
+    for the cardinality constraints (see validate_group)."""
+    union, dataset, unmapped = set(), {}, {}
+    for fi in files:
+        shapes, missing = resolve_shapes(fi.profile_uris, prof_map)
+        if missing:
+            unmapped[fi.path] = missing
+            continue
+        if not keep_boundary:
+            shapes = drop_boundary(shapes)
+        dataset[fi.instance_id] = [p for p in shapes if is_dataset_shape(p)]
+        union.update(shapes)
+    return sorted(union), dataset, unmapped
+
+
+# Group policy — context files are loaded for reference resolution but their
+# violations are reported only in their own group:
+#   cgmes-<Area>         reported: the area's EQ/SSH/TP/SV  context: boundary + commonData
+#   cgmes-boundary       reported: boundary + commonData    context: none (EQBD shapes kept)
+#   cgmes-CGM-Jotunheim  reported: Jotunheim TP/SV + SSH_2  context: every TSO's EQ + boundary
+#   nc-<Area>            reported: the area's NC files      context: the area's Grid + boundary
+# Unmapped CGMES profiles hard-fail (the 4 URIs must always resolve);
+# unmapped NC profiles skip the file with a summary note.
+def build_cgmes_groups(infos, prof_map, apl_dir, rdf_map):
+    grid = [fi for fi in infos if fi.kind == "cgmes"]
+    boundary = [fi for fi in grid if fi.area in ("boundaryData", "commonData")]
+    jotunheim = [fi for fi in grid if fi.area == "Jotunheim"]
+    areas = sorted({fi.area for fi in grid} - {"boundaryData", "commonData", "Jotunheim"})
+
+    common = [apl_dir / rel for rel in CGMES_COMMON_SHACL if (apl_dir / rel).exists()]
+
+    def cgmes_group(name, reported, context):
+        union, dataset, unmapped = shape_split(reported, prof_map, keep_boundary=(name == "cgmes-boundary"))
+        if unmapped:
+            raise SystemExit(f"unmapped CGMES Model.profile URIs (APL PROF broken?): {unmapped}")
+        return Group(name, reported + context, {fi.path for fi in reported},
+                     sorted(set(union) | set(common)), dataset, rdf_map)
+
+    groups = [cgmes_group(f"cgmes-{area}", [fi for fi in grid if fi.area == area], boundary)
+              for area in areas]
+    groups.append(cgmes_group("cgmes-boundary", boundary, []))
+
+    eq_files = [fi for fi in grid if fi.profile_uris[0].startswith("http://iec.ch/TC57/ns/CIM/CoreEquipment")
+                and fi.area != "Jotunheim"]
+    groups.append(cgmes_group("cgmes-CGM-Jotunheim", jotunheim, eq_files))
+    return groups, []
+
+
+def build_nc_groups(infos, prof_map, rdf_map):
+    nc = [fi for fi in infos if fi.kind == "nc"]
+    grid = [fi for fi in infos if fi.kind == "cgmes"]
+    groups, skipped = [], []
+
+    def area_name(fi):
+        return "Jotunheim-GridSituation" if (fi.area, Path(fi.path).parts[2]) == ("Jotunheim", "GridSituation") else fi.area
+
+    for area in sorted({area_name(fi) for fi in nc}):
+        area_files = [fi for fi in nc if area_name(fi) == area]
+        union, dataset, unmapped = shape_split(area_files, prof_map)
+        skipped += [(path, f"unmapped profile URI: {', '.join(uris)}") for path, uris in unmapped.items()]
+        mapped = [fi for fi in area_files if fi.path not in unmapped]
+        if not mapped:
+            continue
+        base_area = area.split("-GridSituation")[0]
+        context = [fi for fi in grid if fi.area in (base_area, "boundaryData", "commonData")]
+        groups.append(Group(f"nc-{area}", mapped + context, {fi.path for fi in mapped},
+                            union, dataset, rdf_map))
+    return groups, skipped
+
+
+def validate_group(frame, group):
+    data = frame[frame["INSTANCE_ID"].isin({fi.instance_id for fi in group.files})]
+
+    # reference checks need the group frame; cardinality must not see the
+    # rdf:about continuation of other files, so it comes from per-file scope=
+    union = data.shacl.validate(group.union_shapes, rdf_map=group.rdf_map)
+    passes = []
+    if len(union):
+        passes.append(union[~union["VIOLATION_TYPE"].isin(PER_DATASET)])
+    for instance_id, shapes in group.dataset_shapes.items():
+        if shapes:
+            per_file = data.shacl.validate(shapes, rdf_map=group.rdf_map, scope=[instance_id])
+            if len(per_file):
+                passes.append(per_file[per_file["VIOLATION_TYPE"].isin(PER_DATASET)])
+    violations = pandas.concat(passes, ignore_index=True) if passes else union
+    if violations.empty:
+        return violations, violations
+    # rdf:about continuation duplicates a fact across files — one finding per fact
+    violations = violations.drop_duplicates(subset=["ID", "KEY", "VALUE", "VIOLATION_TYPE", "SOURCE_SHAPE"])
+
+    all_shapes = sorted({str(p) for p in group.union_shapes}
+                        | {str(p) for shapes in group.dataset_shapes.values() for p in shapes})
+    enriched = violations.shacl.enrich(data=data, shapes=all_shapes, rdf_map=group.rdf_map)
+    located = enriched.shacl.locate(sources=[fi.path for fi in group.files])
+
+    reported = located[located["SOURCE_URI"].isin(group.report_paths) | located["SOURCE_URI"].isna()].copy()
+    # shape-level meta findings (e.g. triplets:invalidSparql) carry no instance
+    # line — anchor them to an in-repo path so GitHub can display the alert
+    anchor = sorted(group.report_paths)[0]
+    reported.loc[reported["SOURCE_URI"].isna(), "SOURCE_LINE"] = 1
+    reported.loc[reported["SOURCE_URI"].isna(), "SOURCE_URI"] = anchor
+    return located, reported
+
+
+def run_schema_pass(frame, infos, config, release):
+    """Schema conformance straight from the export schema, shapes-independent:
+    each instance's declared profiles run separately against its own rows."""
+    files = [fi for fi in infos if fi.kind == config["kind"]]
+    data = frame[frame["INSTANCE_ID"].isin({fi.instance_id for fi in files})]
+    violations = data.shacl.validate_schema(config["rdf_map"])
+    if violations.empty:
+        return None, files, violations
+    located = violations.shacl.locate(sources=[fi.path for fi in files])
+    sarif_path = located.shacl.to_sarif(path=REPORTS / f"schema-{release}.sarif")
+    return json.loads(Path(sarif_path).read_text()), files, located
+
+
+def export_release(release, frames):
+    combined = pandas.concat([f for f in frames if not f.empty], ignore_index=True) if frames else pandas.DataFrame()
+    if combined.empty:
+        return None
+    meta = combined["VIOLATION_TYPE"].astype(str).str.contains("invalidSparql")
+    combined = pandas.concat([combined[~meta],
+                              combined[meta].drop_duplicates(subset=["VIOLATION_TYPE", "MESSAGE", "SOURCE_SHAPE"])],
+                             ignore_index=True)
+    sarif_path = combined.shacl.to_sarif(path=REPORTS / f"shacl-{release}.sarif")
+    return json.loads(Path(sarif_path).read_text())
+
+
+def rule_url(repo, branch, rule_id):
+    """Code-scanning list filtered to one rule — links a summary row to its alerts."""
+    query = quote_plus(f'is:open branch:{branch} rule:"{rule_id}"')
+    return f"https://github.com/{repo}/security/code-scanning?query={query}"
+
+
+def write_summary(release_sarifs, group_stats, skipped, gaps):
+    lines = ["# SHACL validation — PROF-driven full sweep", ""]
+    repo, branch = os.environ.get("GITHUB_REPOSITORY"), os.environ.get("GITHUB_REF_NAME")
+    if repo and branch:
+        alerts = f"https://github.com/{repo}/security/code-scanning?query=is%3Aopen+branch%3A{branch}+tool%3A%22triplets-shacl%22"
+        lines += [f"**[Open the code scanning alerts of this branch →]({alerts})**", "",
+                  "Full sh:ValidationReports (turtle + RDF/XML) per group are attached as the `shacl-reports` artifact.", ""]
+
+    lines += ["| group | files | errors | warnings | notes | seconds |", "|---|---|---|---|---|---|"]
+    for name, file_count, severities, seconds in group_stats:
+        lines.append(f"| `{name}` | {file_count} | {severities.get('Violation', 0)} | "
+                     f"{severities.get('Warning', 0)} | {severities.get('Info', 0)} | {seconds:.1f} |")
+
+    for release, sarif in release_sarifs.items():
+        if sarif is None:
+            continue
+        lines += ["", f"## {release} rules (grouped)", "", "| rule | level | occurrences |", "|---|---|---|"]
+        for result in sarif["runs"][0]["results"]:
+            icon = LEVEL_ICONS.get(result["level"], "")
+            count = result.get("occurrenceCount", len(result.get("locations", [])))
+            rule = f"`{result['ruleId']}`"
+            if repo and branch:
+                rule = f"[{rule}]({rule_url(repo, branch, result['ruleId'])})"
+            lines.append(f"| {rule} | {icon} {result['level']} | {count} |")
+
+    if skipped:
+        lines += ["", "## Skipped files", "", "| file | reason |", "|---|---|"]
+        lines += [f"| `{path}` | {reason} |" for path, reason in skipped]
+    if gaps:
+        lines += ["", "## Profile library gaps", ""]
+        lines += [f"- {gap}" for gap in sorted(set(gaps))]
+    lines += ["", "Notes: Simple shapes run per instance file (scope=) so rdf:about continuation across a "
+              "model set is not double-counted; Complex/AllProfiles shapes run on the group frame; "
+              "EquipmentBoundary shapes run only on the boundary group; the cross-cutting AllProfiles "
+              "shapes are added manually (no PROF references them); variant shape sets "
+              "(SolvedMAS/NotSolvedMAS, CrossProfile, InverseAssociation; role/validation) are not run."]
+    (REPORTS / "summary.md").write_text("\n".join(lines) + "\n")
+
+
+def main():
+    os.chdir(REPO_ROOT)  # relative source paths => repo-relative SARIF artifact URIs
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apl", action="append", default=[], metavar="RELEASE=PATH",
+                        help="APL checkout per release, e.g. cgmes-3.0=.apl-main (repeatable)")
+    parser.add_argument("--only", choices=sorted(RELEASES), help="run a single release")
+    args = parser.parse_args()
+    for override in args.apl:
+        release, _, path = override.partition("=")
+        RELEASES[release]["apl"] = path
+
+    print("triplets", triplets.__version__)
+    REPORTS.mkdir(exist_ok=True)
+    frame, infos, skipped = scan_instances()
+    print(f"parsed {len(frame):,} triples from {len(infos)} mapped files ({len(skipped)} skipped)")
+
+    group_stats, release_sarifs, all_gaps = [], {}, []
+    relations = cgmes_tools.get_model_relations(frame)
+    missing = relations[relations["INSTANCE_ID_TO"].isna()]
+    if len(missing):
+        all_gaps += [f"declared model dependency not loaded: {row.ID_FROM} -[{row.KEY}]-> {row.ID_TO}"
+                     for row in missing.itertuples()]
+    print(f"model dependencies: {len(relations)} declared, {len(missing)} not loaded")
+    for release, config in RELEASES.items():
+        if args.only and release != args.only:
+            continue
+        apl_dir = Path(config["apl"]).resolve()
+        prof_map, gaps = build_prof_map(apl_dir)
+        all_gaps += [f"{release}: {g}" for g in gaps]
+        if not prof_map:
+            raise SystemExit(f"{release}: empty PROF map at {apl_dir}")
+
+        if config["kind"] == "cgmes":
+            groups, more_skipped = build_cgmes_groups(infos, prof_map, apl_dir, config["rdf_map"])
+        else:
+            groups, more_skipped = build_nc_groups(infos, prof_map, config["rdf_map"])
+        skipped += more_skipped
+
+        frames = []
+        for group in groups:
+            start = time.monotonic()
+            located, reported = validate_group(frame, group)
+            seconds = time.monotonic() - start
+            severities = reported["SEVERITY"].value_counts().to_dict() if len(reported) else {}
+            group_stats.append((group.name, len(group.report_paths), severities, seconds))
+            print(f"{group.name}: {len(group.report_paths)} files, {seconds:.1f}s, {severities or 'conforms'}")
+            if len(located):  # full unfiltered report incl. context-file findings
+                for suffix in ("ttl", "xml"):
+                    located.shacl.to_shacl_report(
+                        path=REPORTS / f"{group.name}-shacl-report.{suffix}", report_source=group.name,
+                        report_references=sorted({p.name for p in group.union_shapes}
+                                                 | {p.name for s in group.dataset_shapes.values() for p in s}))
+            frames.append(reported)
+        release_sarifs[release] = export_release(release, frames)
+
+        start = time.monotonic()
+        schema_sarif, schema_files, schema_located = run_schema_pass(frame, infos, config, release)
+        if schema_sarif:
+            release_sarifs[f"schema-{release}"] = schema_sarif
+            severities = schema_located["SEVERITY"].value_counts().to_dict()
+            group_stats.append((f"schema-{release}", len(schema_files), severities, time.monotonic() - start))
+            print(f"schema-{release}: {len(schema_files)} files, {time.monotonic() - start:.1f}s, {severities}")
+
+    write_summary(release_sarifs, group_stats, skipped, all_gaps)
+    for key, sarif in release_sarifs.items():
+        if sarif:
+            name = key if key.startswith("schema-") else f"shacl-{key}"
+            print(f"wrote reports/{name}.sarif: {len(sarif['runs'][0]['results'])} grouped results")
+    print(f"wrote {REPORTS / 'summary.md'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ license = "CC-BY-SA-4.0"
 requires-python = ">=3.12"
 dependencies = [
     "pandas",
-    "triplets",
+    "triplets[polars,oxigraph,validation]==0.2.0",
     "pytest",
     "tabulate>=0.10.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -11,21 +11,21 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "aniso8601"
-version = "10.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8b/8d/52179c4e3f1978d3d9a285f98c706642522750ef343e9738286130423730/aniso8601-10.0.1.tar.gz", hash = "sha256:25488f8663dd1528ae1f54f94ac1ea51ae25b4d531539b8bc707fed184d16845", size = 47190, upload-time = "2025-04-18T17:29:42.995Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/75/e0e10dc7ed1408c28e03a6cb2d7a407f99320eb953f229d008a7a6d05546/aniso8601-10.0.1-py2.py3-none-any.whl", hash = "sha256:eb19717fd4e0db6de1aab06f12450ab92144246b257423fe020af5748c0cb89e", size = 52848, upload-time = "2025-04-18T17:29:41.492Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "html5rdf"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/55/1b839c43f5ed8207e17a9a02d8b395179520b8b4f00c00a41e113bc205ca/html5rdf-1.2.1.tar.gz", hash = "sha256:ace9b420ce52995bb4f05e7425eedf19e433c981dfe7a831ab391e2fa2e1a195", size = 287899, upload-time = "2024-10-30T05:06:56.384Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/c9/f6e1e8567660bc5b0aba281f2b0017b2a7665fcad6bf3ed67286a0c72cd4/html5rdf-1.2.1-py2.py3-none-any.whl", hash = "sha256:1f519121bc366af3e485310dc8041d2e86e5173c1a320fac3dc9d2604069b83e", size = 109765, upload-time = "2024-10-30T05:06:52.507Z" },
 ]
 
 [[package]]
@@ -179,6 +179,31 @@ wheels = [
 ]
 
 [[package]]
+name = "owlrl"
+version = "7.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "rdflib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/08/50dd7fd0c64775d3d6309f35c0cc9a9d635f392f94ee2c4f9122404f7f86/owlrl-7.6.2.tar.gz", hash = "sha256:c743f35c2d908396e77823852bb1ebbce88340cd49961493983bec42c93283a8", size = 48564, upload-time = "2026-07-08T08:38:26.462Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/5e/314be7440bf28dbd47f85321a7434c5b74179a762228487d6493c01bddce/owlrl-7.6.2-py3-none-any.whl", hash = "sha256:83347bf7f133979e87b2b18695d51d25510b99cec3f6919b5df05d4fbf058ae0", size = 55814, upload-time = "2026-07-08T08:38:23.842Z" },
+]
+
+[[package]]
+name = "oxrdflib"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyoxigraph" },
+    { name = "rdflib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/97/589f244d9a12e033f5216595ef17e7975aabe7f906f709a3a8d1cde37288/oxrdflib-0.5.0.tar.gz", hash = "sha256:f83148e2c6d443f7718c6e8936c6b89e36ebb4f1002da69e8f0656e8fb5a0df2", size = 7708, upload-time = "2025-09-13T19:11:32.584Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/f7/9cee8d87f202f88d93179db083508c898deac42b235ff20ade1f456770a1/oxrdflib-0.5.0-py3-none-any.whl", hash = "sha256:dbe7b57bddca1b2acaf93c71ce3cf2022be8e673052e05ad317682cb9c56b559", size = 9925, upload-time = "2025-09-13T19:11:31.368Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -249,12 +274,143 @@ wheels = [
 ]
 
 [[package]]
+name = "polars"
+version = "1.44.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/73/258a1fe17bb2744a507199566ed712663144fdd0811b615b59a47dfa38d2/polars-1.44.1.tar.gz", hash = "sha256:ef3c89e9ebbbe8eb343c06873f1945683f8b6f97a1bdf001c60551c6c5e3cda1", size = 765660, upload-time = "2026-08-26T07:09:12.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/f1/59154659081930fbde291ea6225607956b500a71b0ce45d88217b7d32da2/polars-1.44.1-py3-none-any.whl", hash = "sha256:1fa62fc1c88fba77a68b28291b5aabdd69e5f38b34e59721a064ae3169b59bb5", size = 865208, upload-time = "2026-08-26T07:07:44.646Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.44.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/b2/2a76415d047a45df05489f2334c91ff120a274cf655d4ca030c7f54a8743/polars_runtime_32-1.44.1.tar.gz", hash = "sha256:abd10a54ed1caff42228610fcba0f93251f9870bd7cffb0c78bc26f5e0718ce4", size = 3171156, upload-time = "2026-08-26T07:09:14.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/93/ef9344dcec16757cf21027dc907ef989197e50742cfe4407f2e87edb0a7f/polars_runtime_32-1.44.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:1dfccb2b52aa50468a7d28e3e61c8338a13fb5bffc8646e388a649f5bdc6b463", size = 53962370, upload-time = "2026-08-26T07:07:47.21Z" },
+    { url = "https://files.pythonhosted.org/packages/10/da/38b32b7901af33f1fee2172ceaa39e9159825657920064298917392d78fa/polars_runtime_32-1.44.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:0580807dc3eed258f0db70bb65d905dd43f0135392119ec25308033ae24258fb", size = 48620468, upload-time = "2026-08-26T07:07:50.436Z" },
+    { url = "https://files.pythonhosted.org/packages/49/51/185af877d1d2236671493cf72bd3327a6046240eeea69c0696d1af2a5acb/polars_runtime_32-1.44.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0627f9aa82cb869725235e5188f698862fd9ada0c8c1cf65c3dc5a49a4a0ec26", size = 52455947, upload-time = "2026-08-26T07:07:53.776Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/0a/0858f60cb5a6f8f73ec4cdd73eccd9f748d66bfc23304c5c23fa3468094a/polars_runtime_32-1.44.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eea4283be8e60822d890dbda20588fe59b4172b508bd5ebf3471e531ca9f50d7", size = 58561262, upload-time = "2026-08-26T07:07:57.508Z" },
+    { url = "https://files.pythonhosted.org/packages/73/08/de4774b5612d7c8739f89ac01b601486b4f057b1da35a5b876bf9276fd95/polars_runtime_32-1.44.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:04e2c0f46e7a9906fffb1897f18f23b079b74f83c56b50060bace9e7b9b49b1a", size = 52636064, upload-time = "2026-08-26T07:08:06.337Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ac/769c598dd106e2a6647798da3ed25ddeee67f2d12c04f5da316cb3da6360/polars_runtime_32-1.44.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0956f0cae632d8fad3a04b4315bf2bb69b56d10c83c79a75c2c4c5a13b9ce5cc", size = 56447612, upload-time = "2026-08-26T07:08:12.36Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/ee/98408296e15388020b6183323fdbe78ccab4f72c20d8e0d7092c062d3ad2/polars_runtime_32-1.44.1-cp310-abi3-win_amd64.whl", hash = "sha256:159334184e6fbb074c9f4692221ea19970a5e2bed2a479f9d7bdb00b7f3eedb9", size = 53702970, upload-time = "2026-08-26T07:08:15.398Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9d/8b17e075aac73c881a50b6c1f690d20df46db2f3bcabc99f600ecdee1290/polars_runtime_32-1.44.1-cp310-abi3-win_arm64.whl", hash = "sha256:3ba28d638d0513e0b4afbcdab5c0059a85021e5f81d62b5f793e7e23badb2cf7", size = 47281050, upload-time = "2026-08-26T07:08:18.43Z" },
+]
+
+[[package]]
+name = "prettytable"
+version = "3.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/74/ba08d81e668ccfe8658d7520a307e63c19862c08eb4ccb26f356c5239a7a/prettytable-3.18.0.tar.gz", hash = "sha256:439217116152244369caf3d9f1caf2f9fe29b03bd79e88d2928c8e718c95d680", size = 76373, upload-time = "2026-06-22T16:07:50.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/be/2e6798ace5cc036f5d05d36b7b2fd85346f1a708c87060890b070d0ec607/prettytable-3.18.0-py3-none-any.whl", hash = "sha256:b3346e0e6f79180833aebaac088ae926340586cf6d7d991b9eb125b65f72313a", size = 37357, upload-time = "2026-06-22T16:07:48.595Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "25.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/e3/27f57f80141379d60defe6703eb50a707325706f07fedfd1312c7a751995/pyarrow-25.0.1.tar.gz", hash = "sha256:9150a83248bfed9813ea3c3af74c3856c1984d444aa28e58bf7733b9750ddf6a", size = 1201653, upload-time = "2026-08-10T12:40:53.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/e2/9ab15b88cbfac28e16419ce5439ec29234c5172cb8259301b4ba639bdec0/pyarrow-25.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:df961f2e7ae9cf496459259d798652c70625f6c080650d6952f8c04053c58ee9", size = 35861559, upload-time = "2026-08-10T12:38:02.567Z" },
+    { url = "https://files.pythonhosted.org/packages/58/79/a0036dbe1eabe1f73127427342f1d99982584c4a2cde2651d6c93499c6f6/pyarrow-25.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:cc4aa407fde9fc660be3939e49ea31f50f3e9fec17c0ec63159f7711edd3efc9", size = 37628383, upload-time = "2026-08-10T12:38:09.083Z" },
+    { url = "https://files.pythonhosted.org/packages/13/49/d93a57d375f4bf0cf82913dd6bb54acafde83dd993be2282c81ac5616cad/pyarrow-25.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:4340f0ba6c1d2e13f21658de1d7c662ca2545018568d0030a1e9afca159d87e3", size = 46820190, upload-time = "2026-08-10T12:38:15.458Z" },
+    { url = "https://files.pythonhosted.org/packages/60/c9/711ca85d79f1ec98f29a5eae2b051e25b4ecec5de3e3c0e2d5c5dcb15664/pyarrow-25.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5389cdf79447ed1515c9e31620e6e1e2302249564d603f2ad727d4f6d313e4c3", size = 50102437, upload-time = "2026-08-10T12:38:22.487Z" },
+    { url = "https://files.pythonhosted.org/packages/80/53/8fb8359ff17cfb6263a1cf3ebf7caec9fe197de118719e84fcb1d0618026/pyarrow-25.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d51592cb7561e87877c506113e7adbf1342ab579e6c21f0ef44b8ba41cb74c80", size = 49942424, upload-time = "2026-08-10T12:38:28.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/83/4e5ae02a9341571b18a6fca380ac7a58ce6ddae7ab3c060208c0a1e79f02/pyarrow-25.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6109c94d8b9f3b17a041daca16cacb2f651ad8f1ef70a4232c2c0f37a23da2a8", size = 53144206, upload-time = "2026-08-10T12:38:34.862Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ee/197cbf47e49f83e6ebeb946a5259a48a638dea27ac774db42fe78022179d/pyarrow-25.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:8858d7bfc22e3f51529aeaa4077225029724623e4595dc9eff8c793935c34140", size = 27953934, upload-time = "2026-08-10T12:38:39.808Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/8d/8f271a7a034c834910ec925d56fa4b29733b1380f5289419f5aaa3b02777/pyarrow-25.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:c7c534ec03c358a76ea3e505e74c1b6aef290af90c444dfd092dbfe23e755b85", size = 35855328, upload-time = "2026-08-10T12:38:45.489Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/cd/5bac242f4e841b9971d5eb94fdfe2577e2b70be983e27401e72055786037/pyarrow-25.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:dda9470024204d7bbf2042b47c6e8a0e47a3eeb8e34405882dfaea6577e0c153", size = 37622415, upload-time = "2026-08-10T12:38:51.107Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1f/96d03b4e1506524f7087adb0fd6b2f69f0c9c7aaff1ec36d8030082e15a5/pyarrow-25.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:44a9120ce5bd81936b8ab9a88076e3fd47c2c6838e0e43630fed83626aca81d9", size = 46813813, upload-time = "2026-08-10T12:38:57.773Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d6/33a411115b61dbfc16ad6ad73e71730f6fea654ee3667673bc53ab0e2fe7/pyarrow-25.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0befcf816e45a1af33ac775a9970b749e4868a230c7372f0ae5e932bee27039f", size = 50104452, upload-time = "2026-08-10T12:39:04.579Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ae/b1b97c9ca87f9f9ddbb5230c798df94eccce61bd79b9b45458c69a478588/pyarrow-25.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3f89685964f46e4216103c75483aac0c0692a5f72212d7ca835adba5ede56ce3", size = 49951343, upload-time = "2026-08-10T12:39:11.8Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9e/a112df5cfd5a68cb1d9fc31cfe38c28d5aec9f10865ce37ecef2e4450873/pyarrow-25.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6943e2fe7954d29d84de45d29d34c8dc36ce96570e67d89aa9976e650a4a9138", size = 53144784, upload-time = "2026-08-10T12:39:20.503Z" },
+    { url = "https://files.pythonhosted.org/packages/31/24/97e8bd98f1e3b07e2ba08bcdff690674fbe16d69a7d2712cc3884665e615/pyarrow-25.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:31e49a7888fcdf3a835da33ae777f6bb9a866334e5a789282fc26dcf426f7f15", size = 27870159, upload-time = "2026-08-10T12:39:26.161Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4c/b525824ad3094076919273cd97db61fb3d78252dee76fa3b8dc8f76774aa/pyarrow-25.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:bf0b672390cdcb640d7288f96b826d71ff4e9abb254a86c89890baf51a29cee6", size = 35885255, upload-time = "2026-08-10T12:39:32.366Z" },
+    { url = "https://files.pythonhosted.org/packages/08/62/448bb0e940de41aec31d1a956e63ad9c54afdf122a103cc3ab20c2a3ce33/pyarrow-25.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:38a9a4b4b9613380e200641891495a56c3d5a98a092db4a870af9975e220471d", size = 37644461, upload-time = "2026-08-10T12:39:38.142Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/9a/13587e38bd4806fd218f50fd13b8903fab60588a699ff0c406372e5b4043/pyarrow-25.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b726ad7e7b669be982b0c71c07fe4b037d654354130da79a7902a669e93a66b", size = 46877146, upload-time = "2026-08-10T12:39:43.722Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/61/1c5d1229fa21da4cff5365e41e57177aaac57c563c727f35419b8513d1c1/pyarrow-25.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:9171748cdf796972d85a4b60157c279913e242992e350c90c7450182a9838b2a", size = 50131616, upload-time = "2026-08-10T12:39:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/43/20/291e1d65cc0b09aa19f03cf25cf51a2f5fa94b5db315178f2d254ed5cad4/pyarrow-25.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b7a296aac7a71fa0886c08e155ddb6c636a50013f801f6178daafa0f9e726188", size = 50008879, upload-time = "2026-08-10T12:39:56.891Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7c/1b7c9ec28e76576337e4f97b31141c9a181b89b6d1d6221e9d8205621a58/pyarrow-25.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0fe7c8b6c03969b49c8c66182e4a18e3819ab92d07cfab5d8370c531b9369ef0", size = 53170864, upload-time = "2026-08-10T12:40:04.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/75/f3d789dc06011a765d14d86bda799cf72ac1d715b6a6edecaa0d73d95062/pyarrow-25.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:f729cfdbd36fd99d543b67a914d2de044c84ebe45be8b34902b299b608c15c8f", size = 28620729, upload-time = "2026-08-10T12:40:51.41Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/05/647a8ee6f7c2662feb6921315617bc04dcd6034763fb61b1199720bf6162/pyarrow-25.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:59a2de54c0cbd954da861eee4d1d330f8e909c45b53455baef696380f2c55033", size = 36130288, upload-time = "2026-08-10T12:40:11.014Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f8/c9ee997554d7bea94520667dd1933f109ac1da3ee3556d2b49381e023484/pyarrow-25.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:35935cd5de130aa5cf4dea052a63e6bf2e17006c35c3a468194242b9b2bf5956", size = 37762187, upload-time = "2026-08-10T12:40:16.592Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/08/a28c01c7fe9e96e8233ce2d13df1d402f4f999f848f51d2daacd6bb4c036/pyarrow-25.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:f3831aaa25c67a99f99dc8b05873cb9d64560390372e2aa197ce9dd4a3f06a44", size = 46888003, upload-time = "2026-08-10T12:40:23.242Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b9/58612e977d28dc58c878448866838369ee8da2f1e7cc8ed2c84b952aafee/pyarrow-25.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6a1fdfc6659b6b19022f2e50627fb5cf7156a66c46bf4299379955cbe742382a", size = 50079036, upload-time = "2026-08-10T12:40:29.169Z" },
+    { url = "https://files.pythonhosted.org/packages/72/13/66e1402dcc860e1dc2760b1e0292c9a569b62b3bccab69def1b3e907d006/pyarrow-25.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:169d3429d5be7c752125890620f75a60776d38b0035eddae939651640822332e", size = 50040226, upload-time = "2026-08-10T12:40:35.186Z" },
+    { url = "https://files.pythonhosted.org/packages/78/10/3f1a5497a7ef732ab0f03ecca3e66d89d9c0f57fdc61b4794c456b781f01/pyarrow-25.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:119297a6dc197e45d9c6d4415f7814a67ffa36c180d26f68c154c58067ae782d", size = 53149035, upload-time = "2026-08-10T12:40:41.454Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c0/37d4a7e8e2f7a6076283673d5298018ca26478b934c6ee369e10505ab32c/pyarrow-25.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4288f27577352d608ca08553b0865e4a9b3aa14820c5d95b53337218d609835b", size = 28753071, upload-time = "2026-08-10T12:40:46.623Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyoxigraph"
+version = "0.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/a8/a06280358352a5fddf8c0753af7ec679a223008448e0602671209db0a390/pyoxigraph-0.5.9.tar.gz", hash = "sha256:fe2bea0f41f5284b6dad99ea718d7ff03600068cdf8736b63a9e6cd05f056b19", size = 5302359, upload-time = "2026-06-18T17:09:13.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/0f/3ae7a5cf9d4a2fab482ebe807316e18d55fea32cd52f0fff88fa6ece3f58/pyoxigraph-0.5.9-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6ab699861035163e89bc512ce20aa6e91b654e4d33114c9f5facab08f0fe3d7e", size = 7684369, upload-time = "2026-06-18T17:08:17.867Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/08/ea04c09eb740bee7eeb57ea1769ec4088bfd55b24fc6f931bea317a65512/pyoxigraph-0.5.9-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5a8a1b2debadb5fe79f8b89cbe1193e9c0e6fc1cf0c9431b6be706234beeabbe", size = 8202216, upload-time = "2026-06-18T17:08:19.95Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c1/f03ecc4fb5a09b4e6632218dece98073f3c4f0cdfc4823aedaea0186aa82/pyoxigraph-0.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:d04806073905f448a48811b217115e71224be7f1d4075d1f5f5ec07a016f42ae", size = 5388427, upload-time = "2026-06-18T17:08:21.916Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/497bd58a038ca83ec289a56d35fcad2183f4a180c787aa04268d2a88d4fd/pyoxigraph-0.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:379bef7f8fc38f638f358b1e12bc5bdc908a0e7d47157f4399bf103c727a66da", size = 5044584, upload-time = "2026-06-18T17:08:23.644Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/05/ac08fccf52372f4a91bb97d07c0dba8e3644616aa6907a5864a6a26bb3ae/pyoxigraph-0.5.9-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:bcac65148bddcd0ae24ee1bf20a2e89cc225a926b9e9996eb64dcce60400d1a3", size = 7684737, upload-time = "2026-06-18T17:08:25.463Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b4/7493acbbbe18c9649782f1942d3877ab3f7ad08b5746153f2b4f4d62d2f7/pyoxigraph-0.5.9-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:57f3619c7860f4c95ddab077e4a3dedb7ca4cf191bd81096db835264d414ec5b", size = 8202316, upload-time = "2026-06-18T17:08:27.467Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b4/55368af8a83e7811d25155cf2fc62a814b77594aadb98d3906086b203e1c/pyoxigraph-0.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:4f8ff48b873157ab38e2595a56d6d2008471a45853f5fffc645658c6f69c07db", size = 5390781, upload-time = "2026-06-18T17:08:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/47/0e/ef38dc2ee3b6f89f356f3016c7dd3cf9b4b5153f934a841aa32bfcc594ac/pyoxigraph-0.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:b829233ea4445ccd1032d02e9189432a77e16888a79313498aa501b8731dc925", size = 5046172, upload-time = "2026-06-18T17:08:31.25Z" },
+    { url = "https://files.pythonhosted.org/packages/51/f5/7a97cf8fc761d55057a029725dcffef561390ed565a5504f895a409034f7/pyoxigraph-0.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:e9ca7cd7666336fcbafd9a2ec7d598dd859b7bd2ca7b0838a0f7b92dd3828c28", size = 5387927, upload-time = "2026-06-18T17:08:33.075Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c3/c9a7dfb5fc6f60488f67214e79696a6b5312d612ed4dcc57a62363632f49/pyoxigraph-0.5.9-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:f9154bea122c0bab11eda7604b27ceb424ab8ba1637250503008b8c6632ea405", size = 7682217, upload-time = "2026-06-18T17:08:34.851Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/23/f83d0af4504ac0f80bfe938eea04713c8801bf135f7b91bc52fff55b3e06/pyoxigraph-0.5.9-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4558d430bbad6e6b4ba98e0e89a2e28402211069d38e6e9b00083ae2d9d2d175", size = 8200691, upload-time = "2026-06-18T17:08:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/12/36/b82fa34b525c27a0262ff1007af014706be4485158c9d7bd49fec14b84e3/pyoxigraph-0.5.9-cp314-cp314-win_amd64.whl", hash = "sha256:79caf78136a8312e506beb607910cc5a93662a05a173aa9b560ce9d08801384f", size = 5386008, upload-time = "2026-06-18T17:08:38.345Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ca/3c1a7fc7fa5641173d6f91dc58e3cea47e7571716a9aafb909039e1f885b/pyoxigraph-0.5.9-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:917d976dcb813d613d0ddd7da1c9dec6ad02ee815015f393c703cf0804946653", size = 7675486, upload-time = "2026-06-18T17:08:40.171Z" },
+    { url = "https://files.pythonhosted.org/packages/89/aa/0c7e0c2c07e29676f78bfc38a5712b0c4e087d0dbde72b4c6b54b47f231d/pyoxigraph-0.5.9-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:68f8daf082ea4bf9583abd10b64e23cd2c4a3285338a5ec24254181d45e63083", size = 8197760, upload-time = "2026-06-18T17:08:42.069Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/c5/c37b33219897bd1e016181644efc22f15abfa16fbf9ba6e3db7c7f55dc09/pyoxigraph-0.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:b8884b0ce3ccbac99ebc2c995614a13dc5f5d86b0adb847f36aeb1c713d12946", size = 5382226, upload-time = "2026-06-18T17:08:43.836Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d4/543c3a613f9b39ce06f0c052f36a0c5933157724176c04508e407e73fb98/pyoxigraph-0.5.9-cp38-abi3-macosx_10_14_x86_64.whl", hash = "sha256:8b998bc479a54a8905cdeaad621d0f7fed212abf9f1cbededfde4c51fc8e3bb8", size = 6306670, upload-time = "2026-06-18T17:08:45.616Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/28/080334bc7a4540a2102460f55557c04aadf9f2282c15896f4e9d998982d8/pyoxigraph-0.5.9-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:5c9f93db5e14a03ac1e3934cece3fb6f7c0a9f4bde33082c72c788c12bf65ba4", size = 5786471, upload-time = "2026-06-18T17:08:48.314Z" },
+    { url = "https://files.pythonhosted.org/packages/76/4f/50fd2f11b733eeea8f0c6c7804fc22d1bcf7a43ef8d61a1ad8f18a1f9ce4/pyoxigraph-0.5.9-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:afe19bd1835a7245caad06cc9bb1a5c861882dc074fdfa24ba2626e3bbf9866a", size = 7683430, upload-time = "2026-06-18T17:08:50.397Z" },
+    { url = "https://files.pythonhosted.org/packages/12/d7/80f6d4dd5aa7f02b6020e75216213460b84edd7e32d32155507523a04b2b/pyoxigraph-0.5.9-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3bd1925a8185320bcb8c549cccafbb423cc3957513890e6f420b8e355055052a", size = 8204009, upload-time = "2026-06-18T17:08:52.493Z" },
+    { url = "https://files.pythonhosted.org/packages/82/94/da29a7d85340f119be878136507a8cbf4640ed5fe2b0dbc68fd67a1f807c/pyoxigraph-0.5.9-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f619aac7199b2ba91cade2fe69f64b4c73abb1e6b33735b0ff7205a753e609cd", size = 8865946, upload-time = "2026-06-18T17:08:54.477Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/42/222017d65d411f1993585d51b977b65680ecc0edbc28609f702a65107e65/pyoxigraph-0.5.9-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:09071f6c08b9489723dec96e2d96f64a15b9be2d165d3bbf67d40712884ba7a3", size = 9414073, upload-time = "2026-06-18T17:08:57.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/8a/7ba44c596afa3377a9c75f6ff76de91e8e45a18df72d17cb74efbb02db92/pyoxigraph-0.5.9-cp38-abi3-win_amd64.whl", hash = "sha256:efd3d03bd2a36f9b0bdf3ce70d76ce5278c481fe961d14c2bb6efcac10f57ae2", size = 5391422, upload-time = "2026-06-18T17:08:59.508Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/46/b092a22596c7ed11b0b26b3dade2dede638fc6a3e61ee7e5168aa3481948/pyoxigraph-0.5.9-cp38-abi3-win_arm64.whl", hash = "sha256:94c2a8b52c1ed6e445a235a4f89cd460eea936f399d28df5e9927826bf52f032", size = 5048182, upload-time = "2026-06-18T17:09:01.419Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyshacl"
+version = "0.40.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "owlrl" },
+    { name = "packaging" },
+    { name = "prettytable" },
+    { name = "rdflib", extra = ["html"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/b8/f92465fead905b7c5365631a3997107c896cf1e32f4f9a163bdaee54e4fb/pyshacl-0.40.1.tar.gz", hash = "sha256:011e3cf1a68b31747cb762ba3d755ae1bdcc464c8fad0dc212a9adc550719552", size = 1444205, upload-time = "2026-07-28T01:37:36.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/90/7f35a79db93032ef20db5b740062b54afba32a2c2475a6f0a43c141a69de/pyshacl-0.40.1-py3-none-any.whl", hash = "sha256:27dd58c8ddfa103303b4a8c40b2c666332ffc912dbcd3137f7adc7b7bc5e6bda", size = 1306209, upload-time = "2026-07-28T01:37:34.298Z" },
 ]
 
 [[package]]
@@ -286,6 +442,23 @@ wheels = [
 ]
 
 [[package]]
+name = "rdflib"
+version = "7.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f5/18bb77b7af9526add0c727a3b2048959847dc5fb030913e2918bf384fec3/rdflib-7.6.0.tar.gz", hash = "sha256:6c831288d5e4a5a7ece85d0ccde9877d512a3d0f02d7c06455d00d6d0ea379df", size = 4943826, upload-time = "2026-02-13T07:15:55.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/c2/6604a71269e0c1bd75656d5a001432d16f2cc5b8c057140ec797155c295e/rdflib-7.6.0-py3-none-any.whl", hash = "sha256:30c0a3ebf4c0e09215f066be7246794b6492e054e782d7ac2a34c9f70a15e0dd", size = 615416, upload-time = "2026-02-13T07:15:46.487Z" },
+]
+
+[package.optional-dependencies]
+html = [
+    { name = "html5rdf" },
+]
+
+[[package]]
 name = "relicapgrid"
 version = "0.1.0"
 source = { virtual = "." }
@@ -293,7 +466,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pytest" },
     { name = "tabulate" },
-    { name = "triplets" },
+    { name = "triplets", extra = ["oxigraph", "polars", "validation"] },
 ]
 
 [package.metadata]
@@ -301,7 +474,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "pytest" },
     { name = "tabulate", specifier = ">=0.10.0" },
-    { name = "triplets" },
+    { name = "triplets", extras = ["polars", "oxigraph", "validation"], specifier = "==0.2.0" },
 ]
 
 [[package]]
@@ -324,16 +497,37 @@ wheels = [
 
 [[package]]
 name = "triplets"
-version = "0.0.17"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aniso8601" },
     { name = "lxml" },
     { name = "pandas" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/2e/6db8c9794586df559c7ce721616567c3b2ea43b5340e8260a6df72ce8802/triplets-0.0.17.tar.gz", hash = "sha256:329e791bce2f17fd655c7f06db1ea6a87cdc9a07d50d82effc3867427a8d1ef9", size = 1425470, upload-time = "2025-11-13T01:05:42.303Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/41/9c5705f83455413c35f7dd366bf66e1aba739869743b2d2784b1a1c79e50/triplets-0.2.0.tar.gz", hash = "sha256:5262e7ef618c9cc803560070bffcd4cf259f8c91183c837cf5a694ce8836e6bd", size = 2737600, upload-time = "2026-08-26T14:04:42.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/88/6f943285186de3a885b2256806fd5626e70d501cf9b08a643de16ef653f3/triplets-0.0.17-py3-none-any.whl", hash = "sha256:075f64f6777abd906e51e1e6dddb9fe923bf18fcef374920de68932b8fb295d2", size = 1454850, upload-time = "2025-11-13T01:05:40.709Z" },
+    { url = "https://files.pythonhosted.org/packages/23/03/d5c37fd0d8932a9abd3d675f50b0d09bbc2d7acfeb7631d2b1266c9d9446/triplets-0.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:76e22a2de8953c97a30755cb07fc045266360552ebf5c79c2c3885bdb861ad40", size = 2458392, upload-time = "2026-08-26T14:04:28.039Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f0/604248f8d7fad08921502d4a60edfb837dcd9aa1a4f8ce5066b04859955c/triplets-0.2.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:75fc30559a1749fd11c2773a3119929b0cbf8c1385f22e98a5cc9cc62474ac2e", size = 5127209, upload-time = "2026-08-26T14:04:29.599Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/255989991b61441116e5acda7c659c050ee72e3eeea371671b7503c9cb40/triplets-0.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2acec45809f5c621840f41006e8fd37ccdd22cb3565e8cb782da73033d0a72f", size = 2498790, upload-time = "2026-08-26T14:04:31.138Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9f/972c876f4f4cd09643a77233aced15b42d4c54d75ca3ace8f2511a1ed9bd/triplets-0.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7a68ec607ebec1451cf98a1465ee1beeeb580f8c77724255e5285c9b439bcbdc", size = 2457884, upload-time = "2026-08-26T14:04:32.787Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f8/af81a0bcdbbf68ca2781f3bd4bf926ea528f819df45a1eff62fc6f9b5e07/triplets-0.2.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:131c16bf113a954da82d95501784a4cfa104d02c8f8953205eb9cc43ffa3a1f7", size = 5122518, upload-time = "2026-08-26T14:04:34.625Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/dd/30cde8e4c55388df5b9c5c10dcecfb5790a2dc884c357cdd1aad9ea80b83/triplets-0.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:d96fffde3d874b20a858177c0ec89ca6e4388f4e8fd23a2b59d7646330a00e4e", size = 2498384, upload-time = "2026-08-26T14:04:36.283Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/ad/fe0f3fb74868e0b1719e1311e680b731af1727ef14c0b104d68f80b5c6e8/triplets-0.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6d4fc8481fe521317100be342406fbe53c9f6b2a191171995600d1e9b309991b", size = 2458491, upload-time = "2026-08-26T14:04:37.722Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/27/36af754c6b07c1f3e3774f661663db5c1c9522256266baedcfdba15fb6c5/triplets-0.2.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c084864cc012e597f6ee9f4a7cf099d4b6ead7ce38ed8685e7515bd461414d52", size = 5118089, upload-time = "2026-08-26T14:04:39.405Z" },
+    { url = "https://files.pythonhosted.org/packages/06/50/6048bdb03fc9b9e013ca3a36a5206f45fe9595b542a1c7d1beb38f7c1963/triplets-0.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:0478f6c749d490c26d3042713b7f4044fc43c21ee95d1e37dd42f3cfc7ebffe1", size = 2491952, upload-time = "2026-08-26T14:04:41.188Z" },
+]
+
+[package.optional-dependencies]
+oxigraph = [
+    { name = "oxrdflib" },
+    { name = "pyoxigraph" },
+]
+polars = [
+    { name = "polars" },
+    { name = "pyarrow" },
+]
+validation = [
+    { name = "pyshacl" },
+    { name = "rdflib" },
 ]
 
 [[package]]
@@ -343,4 +537,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]


### PR DESCRIPTION
Ports the PROF-driven validation setup as proposed in #381 (updated results in that thread).

What it adds:
- `buildScripts/prof_map.py` — maps each instance file's declared profile (`md:Model.profile` / `dcterms:conformsTo`) to its SHACL files via the DX-PROF descriptors of the application-profiles-library.
- `buildScripts/validate_instances.py` — validates every `Instance/**/*.xml` (125 files, ~5 min): SHACL constraints in cross-file-resolving groups with per-dataset constraints (`sh:minCount`/`maxCount`/`sh:closed`) evaluated per instance file, plus a shapes-independent schema-conformance layer, plus a `Model.DependentOn`/`requires` resolvability check.
- `.github/workflows/shacl_validation.yml` — uploads four SARIF categories to code scanning (auto-close on fix, auto-open on regression), attaches full sh:ValidationReports (turtle + RDF/XML) and a run summary per run.

Notes for review:
- SARIF uploads use `security-events: write` in the workflow. On this public repo that is sufficient — no CodeQL / Code Security toggle to flip. Alerts appear under Security → Code scanning after the first successful run on the default branch (tool `triplets-shacl`).
- triplets is pinned to `0.2.0`.
- Skipped files (referenceData without an application profile, the Jotunheim/NetworkCode duplicates) are listed with reasons in every run summary.

