### PR TITLE
Set DC-Espheim-Svedala_RA publisher to the DCSO party, and re-enable the header checker's Tier-B

### DIFF
--- a/Instance/DC-Espheim-Svedala/NetworkCode/cimxml/DC-Espheim-Svedala_RA.xml
+++ b/Instance/DC-Espheim-Svedala/NetworkCode/cimxml/DC-Espheim-Svedala_RA.xml
@@ -17,7 +17,7 @@ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <dcterms:conformsTo rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#"/>
     <dcterms:description xml:lang="en">Svedala - HVDC - Espheim  - NC profile</dcterms:description>
     <prov:generatedAtTime>2025-06-19T14:00:00Z</prov:generatedAtTime>
-    <dcterms:publisher rdf:resource="https://ap.cim4.eu/RemedialAction/2.4"/>
+    <dcterms:publisher rdf:resource="https://energy.referencedata.eu/test/party/DCSO-Espheim-Svedala"/>
     <prov:references rdf:resource="urn:uuid:105893e4-668b-4b00-a351-0e436b53cbc9"/>
     <dcat:startDate>2025-06-19T14:00:00Z</dcat:startDate>
     <dcat:keyword>RA</dcat:keyword>

--- a/buildScripts/dataset_header/schemes.py
+++ b/buildScripts/dataset_header/schemes.py
@@ -1,10 +1,19 @@
 """Load the reference-data schemes into valid-value sets for Tier-B checks.
 
-The schemes live under ``Instance/referenceData``. Because they only list a
-subset of parties/frames/models/activities/profiles today, Tier-B checks are
-report-only and best-effort: membership is derived from the URI conventions
-used in the scheme files, so newly added entries become valid with no code
-change. This is exactly the parked PR #322 reference-data work.
+The schemes live under ``Instance/referenceData/NetworkCode/cimxml`` and are the
+``*-Collection-*_RD.xml`` files. Membership is derived from the URI conventions
+used in those files, so entries added to the reference data become valid with no
+code change here.
+
+Because the collections still list only a subset of the parties/frames/models/
+activities/profiles the instance files actually reference, Tier-B stays
+report-only -- that gap is the parked PR #322 reference-data work.
+
+An empty scheme is *not* normal: it means the glob matched no file, and
+``rules.validate_graph`` then skips that check silently. ``missing_schemes``
+reports those keys so the drift is visible instead of reading as a clean run.
+The older ``*Scheme-NCP_RD`` names these globs used to carry survive only under
+``referenceData/NetworkCode/ttl/``, which is how they went stale unnoticed.
 """
 from __future__ import annotations
 
@@ -17,12 +26,14 @@ from rdflib.term import URIRef
 from .rules import PROV
 
 # Scheme key -> (glob under referenceData, URI substring that marks a member).
+# The conformance entry stays a glob so the branch's profile release (NCP-2-4 /
+# NCP-2-5 / ...) is picked up without editing this map.
 _SCHEME_FILES: dict[str, tuple[str, str | None]] = {
-    "model": ("NetworkCode/cimxml/Test-ModelScheme-NCP_RD.xml", "/model/"),
-    "frame": ("NetworkCode/cimxml/Test-FrameScheme-NCP_RD.xml", "/frame/"),
-    "activity": ("NetworkCode/cimxml/ActivityScheme-NCP_RD.xml", "/activity/"),
-    "party": ("NetworkCode/cimxml/Test-PartyScheme-NCP_RD.xml", "/party/"),
-    "conformance": ("NetworkCode/cimxml/ConformanceReleaseScheme-*_RD.xml", None),
+    "model": ("NetworkCode/cimxml/Test-Model-Collection-*_RD.xml", "/model/"),
+    "frame": ("NetworkCode/cimxml/Test-Frame-Collection-*_RD.xml", "/frame/"),
+    "activity": ("NetworkCode/cimxml/Activity-Collection_RD.xml", "/activity/"),
+    "party": ("NetworkCode/cimxml/Test-Party-Collection-*_RD.xml", "/party/"),
+    "conformance": ("NetworkCode/cimxml/ConformTo-Collection-*_RD.xml", None),
 }
 
 
@@ -32,16 +43,26 @@ class Schemes:
     def __init__(self, reference_dir: Path):
         self.reference_dir = reference_dir
         self._values: dict[str, set[str]] = {}
+        self._missing: dict[str, str] = {}
         self._load()
 
     def values_for(self, key: str) -> set[str]:
         return self._values.get(key, set())
+
+    def missing_schemes(self) -> dict[str, str]:
+        """Scheme key -> glob, for every scheme whose glob matched no file.
+
+        A non-empty result means those Tier-B checks are being skipped, so the
+        report understates the findings rather than showing a clean run.
+        """
+        return dict(self._missing)
 
     def _load(self) -> None:
         for key, (rel, marker) in _SCHEME_FILES.items():
             matches = sorted(self.reference_dir.glob(rel))
             if not matches:
                 self._values[key] = set()
+                self._missing[key] = rel
                 continue
             g = Graph()
             for path in matches:

--- a/buildScripts/validate_dataset_header.py
+++ b/buildScripts/validate_dataset_header.py
@@ -66,6 +66,14 @@ def main(argv: list[str] | None = None) -> int:
 
     print(summarize(violations, n_files, headers))
     print(f"Reference schemes loaded: {schemes.summary()}")
+    missing = schemes.missing_schemes()
+    if missing:
+        print(
+            "WARNING: no reference-data file matched these scheme globs, so "
+            "their Tier-B checks were skipped (the counts below understate "
+            "the findings):")
+        for key, glob in sorted(missing.items()):
+            print(f"  - {key}: {glob}")
     print()
     print(by_rule_table(violations))
     if args.details:


### PR DESCRIPTION
Closes #379.

## 1. The RA publisher (`cdc4b14`)

`DC-Espheim-Svedala_RA.xml` carried the RemedialAction profile URI as its
`dcterms:publisher`, copied from the `dcterms:conformsTo` value three lines above.
It has been wrong since the file was first added, and the header auto-fixer could
not reach it — `normalize-publisher` only rewrites values already shaped
`.../test/party/<Name>`, so a profile URI is outside its regex.

**This uses a different value from the one proposed in the issue.** The issue
suggested `TSO-Svedala`, copied from `cgmes-3.0_ncp-2.4_tc-1.1`. But
`Test-Party-Collection-ReliCapGrid_RD.xml` defines `DCSO-Espheim-Svedala`, typed
`nc:DirectCurrentSystemOperator` and described as the joint operating entity for
this HVDC interconnector — and the sibling `DC-Espheim-Svedala_CO.xml` already
publishes under it, on both branches. `TSO-Svedala` is the plain AC TSO. So the two
NCP files for the DC IGM now agree on who operates it.

The 2.4 branch carries the same RA/CO disagreement and will be aligned in a
separate PR.

## 2. Re-enabling the header checker's Tier-B (`e8987b9`)

Found while validating the above: **Tier-B membership checking has been silently
inert since it was written.** The globs in `schemes.py` named files that do not
exist — the `*Scheme-NCP_RD` names survive only under
`referenceData/NetworkCode/ttl/`, while the cimxml sources are
`*-Collection-*_RD.xml`. Every scheme loaded as an empty set, and
`rules.validate_graph` skips a check whose scheme is empty, so the report showed:

```
Tier-B violations: 0 (blocked on reference-scheme extensions)
Reference schemes loaded: activity=0, conformance=0, frame=0, model=0, party=0
```

That reads as a clean run. It was a false clean — nothing had been checked.

Repointing each glob at the collection file that exists gives:

```
Tier-B violations: 372 (blocked on reference-scheme extensions)
Reference schemes loaded: activity=97, conformance=39, frame=14, model=138, party=9
```

| rule | count |
|---|---|
| `unknown-conformance` | 145 |
| `unknown-model` | 73 |
| `unknown-activity` | 72 |
| `unknown-frame` | 48 |
| `unknown-party` | 34 |

Every glob is wildcarded on the release/dataset suffix so a branch picks up its own
profile release without editing the map.

Also added `Schemes.missing_schemes()` and a warning line in the validator CLI, so
a glob matching nothing is reported instead of quietly disabling its check — which
is exactly what let this drift go unnoticed. **A `=0` in the "Reference schemes
loaded" line now means broken, not clean.**

Wiring this up would have caught #379 on its own: the bad publisher is reported as
`unknown-party: dcterms:publisher value not found in party scheme`.

## Not fixed here — worth their own issues

- `rules.py` `PUBLISHER_PATTERN` allows only `(TSO|RCC)-`, so the legitimate
  `DCSO-` parties trip Tier-A `publisher-naming`. The count stays at 7 after this
  PR rather than dropping — the RA file just moves from "not a party URI" to
  "`DCSO-` not in `(TSO|RCC)`".
- `RCC-Jotunheim` (29 headers) and `Org-NineRealms` (2) are absent from the party
  collection entirely — the largest `unknown-party` contributor.
- `prov:wasGeneratedBy` uses `/Activity/CGM-*` repo-wide while the activity
  collection defines `/activity/AC-*` and `/activity/AD-*` — all 72
  `unknown-activity` findings are that one naming mismatch.
- Headers on this branch still `conformsTo` the 2.4 profile URIs — a large share of
  the 145 `unknown-conformance` findings.

## Verification

- `validate_dataset_header.py --scope networkcode --details`: schemes load with no
  `=0`, no warning line, `unknown-party` 35 → 34, and no
  `ap.cim4.eu/RemedialAction/2.4` under either `unknown-party` or
  `publisher-naming`.
- `fix_dataset_header.py` dry-run: still only `Belgovia_SIS`, `Britheim_AE`,
  `Britheim_CO` — the RA file is not touched, so the change is fixer-idempotent.
- `pytest tests/test_dataset_header.py`: 7 passed, 2 xfailed. **CI is unaffected** —
  Tier-B always xfails and Tier-A xfails while `ENFORCE` is `False`; the xfail
  message is simply truthful now. Tier-A is unchanged at 58 + 7.
- `validate_relicap.py`: same 4 dangling references as before. Confirmed
  pre-existing by stashing and re-running on the untouched branch.
- Re-verified after PR #380 (`add-reference-data`) landed, since it touches the
  files these globs point at: filenames unchanged, all five globs still match,
  counts identical.
