### PR TITLE
Set DC-Espheim-Svedala_RA publisher to the DCSO party (v2.4)

### DIFF
--- a/Instance/DC-Espheim-Svedala/NetworkCode/cimxml/DC-Espheim-Svedala_RA.xml
+++ b/Instance/DC-Espheim-Svedala/NetworkCode/cimxml/DC-Espheim-Svedala_RA.xml
@@ -17,7 +17,7 @@ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <dcterms:conformsTo rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#"/>
     <dcterms:description xml:lang="en">Svedala - HVDC - Espheim - NC profile</dcterms:description>
     <prov:generatedAtTime>2025-06-19T14:00:00Z</prov:generatedAtTime>
-    <dcterms:publisher rdf:resource="https://energy.referencedata.eu/test/party/TSO-Svedala"/>
+    <dcterms:publisher rdf:resource="https://energy.referencedata.eu/test/party/DCSO-Espheim-Svedala"/>
     <prov:references rdf:resource="urn:uuid:105893e4-668b-4b00-a351-0e436b53cbc9"/>
     <dcat:startDate>2025-06-19T14:00:00Z</dcat:startDate>
     <dcat:keyword>RA</dcat:keyword>


### PR DESCRIPTION
Branch counterpart to #388 (merged), which fixed the same header on
`cgmes-3.0_ncp-2.5_tc-2.0` for #379.

## The problem

`DC-Espheim-Svedala_RA.xml` published under `TSO-Svedala` while its sibling
`DC-Espheim-Svedala_CO.xml` published under `DCSO-Espheim-Svedala` — the two NCP
files for the DC IGM disagreed on who operates it.

`DCSO-Espheim-Svedala` is the correct one. This branch's own
`Test-Party-Collection-ReliCapGrid_RD.xml` defines it as
`nc:DirectCurrentSystemOperator`, described as the joint operating entity for the
DC-Espheim-Svedala HVDC interconnector. `TSO-Svedala` is the plain AC TSO.

## Relationship to #379 and #388

Issue #379 was raised against the 2.5 branch, where this header carried something
different again — the `RemedialAction` profile URI — and the issue proposed
`TSO-Svedala` as the fix *because that is what this branch had*. Investigating it
showed the 2.4 value was wrong too, just less obviously: the bad value differed
between the branches, but the correct value is the same on both.

So this is not a mechanical port of #388. It is the same conclusion applied to a
different starting value, and it is why #388 did not use the value the issue
suggested.

Only the XML change applies here — `buildScripts/dataset_header/` does not exist on
this branch, so the Tier-B checker repair in #388 has no counterpart.

## Verification

- Both `DC-Espheim-Svedala` NCP files now read
  `.../test/party/DCSO-Espheim-Svedala`.
- `uv run pytest`: 5 passed. Fully green on this branch, including
  `test_dangling_references` — `dcterms:publisher` is an external URI, not an
  intra-model reference, so it cannot affect that check.
